### PR TITLE
Prefer enclosing containers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,15 @@ function createEditor( container, textarea, settings ) {
 
 domReady( () => {
 	document.querySelectorAll( wpGutenbergEverywhere.saveTextarea ).forEach( ( node ) => {
-		const container = createContainer( node, document.querySelector( wpGutenbergEverywhere.container ) );
+		let container;
+
+		// Prefer enclosing containers, so check if one exists outside.
+		const outerContainerNode = node.closest( wpGutenbergEverywhere.container );
+		if ( outerContainerNode ) {
+			container = createContainer( node, outerContainerNode );
+		} else {
+			container = createContainer( node, document.querySelector( wpGutenbergEverywhere.container ) );
+		}
 
 		createEditor( container, node, wpGutenbergEverywhere );
 	} );


### PR DESCRIPTION
Currently, with multiple containers and textareas on a page, they are not properly connected when using CSS classes to do so.

Consider this HTML (of course normally you'd use better defined containers with CSS classes but this demo it's not needed):
```html
<div>
<textarea name="text"></textarea>
</div>
...
<div>
<textarea name="text"></textarea>
</div>
```

Now Gutenberg Everywhere is invoked like this:
```php
$this->load_editor( 'textarea', 'div' );
```

Before this PR, what happens is that both textareas use the first `<div>` as their container. This is because for both instances of the `<textarea>` we invoke `document.querySelector( 'div' )`, no matter where the textarea we try to convert is.

With the change proposed, an enclosing container is prioritized over the first container in the document.
