### PR TITLE
Rename to Blocks Everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gutenberg Everywhere
+# Blocks Everywhere
 
 <img width="1280" alt="110600033-c625d880-8183-11eb-9609-70ab7390c0d9" src="/resources/banner-1544x500.png">
 
@@ -17,7 +17,7 @@ Note that this is still experimental, and may require additional work to fit in 
 The plugin uses the [Isolated Block Editor](https://github.com/Automattic/isolated-block-editor/). This can also be found in:
 
 - [Plain Text Editor](https://github.com/Automattic/isolated-block-editor/src/browser/README.md) - standalone JS file that can replace any `textarea` on any page with a full Gutenberg editor
-- [Gutenberg Chrome Extension](https://github.com/Automattic/gutenberg-everywhere-chrome/) - a Chrome extension that allows Gutenberg to be used on any page
+- [Gutenberg Chrome Extension](https://github.com/Automattic/blocks-everywhere-chrome/) - a Chrome extension that allows Gutenberg to be used on any page
 - [Gutenberg Desktop](https://github.com/Automattic/gutenberg-desktop/) - a desktop editor that supports the loading and saving of HTML and Markdown files
 - [P2](https://wordpress.com/p2/) - WordPress as a collaborative workspace (coming soon for self-hosted)
 

--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Blocks Everywhere
 Description: Because somewhere is just not enough. Add Gutenberg to WordPress comments, bbPress forums, and BuddyPress streams. Also enables Gutenberg for comment & bbPress moderation.
-Version: 1.5.0
+Version: 1.6.0
 Author: Automattic
 Text Domain: 'blocks-everywhere'
 */

--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -1,10 +1,10 @@
 <?php
 /*
-Plugin Name: Gutenberg Everywhere
+Plugin Name: Blocks Everywhere
 Description: Because somewhere is just not enough. Add Gutenberg to WordPress comments, bbPress forums, and BuddyPress streams. Also enables Gutenberg for comment & bbPress moderation.
 Version: 1.5.0
 Author: Automattic
-Text Domain: 'gutenberg-everywhere'
+Text Domain: 'blocks-everywhere'
 */
 
 require_once __DIR__ . '/classes/gutenberg-handler.php';
@@ -12,10 +12,10 @@ require_once __DIR__ . '/classes/comments.php';
 require_once __DIR__ . '/classes/bbpress.php';
 require_once __DIR__ . '/classes/buddypress.php';
 
-class Gutenberg_Everywhere {
+class Blocks_Everywhere {
 	/**
 	 * Instance variable
-	 * @var Gutenberg_Everywhere|null
+	 * @var Blocks_Everywhere|null
 	 */
 	private static $instance = null;
 
@@ -36,11 +36,11 @@ class Gutenberg_Everywhere {
 	/**
 	 * Singleton access
 	 *
-	 * @return Gutenberg_Everywhere
+	 * @return Blocks_Everywhere
 	 */
 	public static function init() {
 		if ( is_null( self::$instance ) ) {
-			self::$instance = new Gutenberg_Everywhere();
+			self::$instance = new Blocks_Everywhere();
 		}
 
 		return self::$instance;
@@ -57,19 +57,19 @@ class Gutenberg_Everywhere {
 	}
 
 	public function load_handlers() {
-		$default_comments = defined( 'GUTENBERG_EVERYWHERE_COMMENTS' ) ? GUTENBERG_EVERYWHERE_COMMENTS : false;
-		$default_bbpress = defined( 'GUTENBERG_EVERYWHERE_BBPRESS' ) ? GUTENBERG_EVERYWHERE_BBPRESS : false;
-		$default_buddypress = defined( 'GUTENBERG_EVERYWHERE_BUDDYPRESS' ) ? GUTENBERG_EVERYWHERE_BUDDYPRESS : false;
+		$default_comments = defined( 'BLOCKS_EVERYWHERE_COMMENTS' ) ? BLOCKS_EVERYWHERE_COMMENTS : false;
+		$default_bbpress = defined( 'BLOCKS_EVERYWHERE_BBPRESS' ) ? BLOCKS_EVERYWHERE_BBPRESS : false;
+		$default_buddypress = defined( 'BLOCKS_EVERYWHERE_BUDDYPRESS' ) ? BLOCKS_EVERYWHERE_BUDDYPRESS : false;
 
-		if ( apply_filters( 'gutenberg_everywhere_comments', $default_comments ) ) {
+		if ( apply_filters( 'blocks_everywhere_comments', $default_comments ) ) {
 			$this->handlers[] = new Gutenberg_Comments();
 		}
 
-		if ( apply_filters( 'gutenberg_everywhere_bbpress', $default_bbpress ) ) {
+		if ( apply_filters( 'blocks_everywhere_bbpress', $default_bbpress ) ) {
 			$this->handlers[] = new Gutenberg_bbPress();
 		}
 
-		if ( apply_filters( 'gutenberg_everywhere_buddypress', $default_buddypress ) ) {
+		if ( apply_filters( 'blocks_everywhere_buddypress', $default_buddypress ) ) {
 			$this->handlers[] = new Gutenberg_BuddyPress();
 		}
 	}
@@ -108,4 +108,4 @@ class Gutenberg_Everywhere {
 	}
 }
 
-Gutenberg_Everywhere::init();
+Blocks_Everywhere::init();

--- a/classes/bbpress.php
+++ b/classes/bbpress.php
@@ -41,7 +41,7 @@ class Gutenberg_bbPress extends Gutenberg_Handler {
 	}
 
 	public function add_to_bbpress( $content ) {
-		$this->load_editor( '.bbp-the-content', '.gutenberg-everywhere' );
+		$this->load_editor( '.bbp-the-content', '.blocks-everywhere' );
 		return $content;
 	}
 

--- a/classes/comments.php
+++ b/classes/comments.php
@@ -35,7 +35,7 @@ class Gutenberg_Comments extends Gutenberg_Handler {
 	 */
 	public function comment_form_defaults( $defaults ) {
 		$defaults['class_container'] .= ' gutenberg-comments';
-		$defaults['comment_field'] .= '<div class="gutenberg-everywhere iso-editor__loading"></div>';
+		$defaults['comment_field'] .= '<div class="blocks-everywhere iso-editor__loading"></div>';
 
 		return $defaults;
 	}
@@ -46,6 +46,6 @@ class Gutenberg_Comments extends Gutenberg_Handler {
 	 * @return string
 	 */
 	public function add_to_comments() {
-		$this->load_editor( '#comment', '.gutenberg-everywhere' );
+		$this->load_editor( '#comment', '.blocks-everywhere' );
 	}
 }

--- a/classes/gutenberg-handler.php
+++ b/classes/gutenberg-handler.php
@@ -59,7 +59,7 @@ abstract class Gutenberg_Handler {
 	public function the_editor( $editor ) {
 		$editor = preg_replace( '@.*?(<textarea.*?</textarea>).*@', '$1', $editor );
 
-		return '<div class="gutenberg-everywhere iso-editor__loading">' . $editor . '</div>';
+		return '<div class="blocks-everywhere iso-editor__loading">' . $editor . '</div>';
 	}
 
 	public function wp_editor_settings( $settings ) {
@@ -124,7 +124,7 @@ abstract class Gutenberg_Handler {
 			}
 		}
 
-		return apply_filters( 'gutenberg_everywhere_allowed_blocks', array_unique( $allowed ), $this->get_editor_type() );
+		return apply_filters( 'blocks_everywhere_allowed_blocks', array_unique( $allowed ), $this->get_editor_type() );
 	}
 
 	/**
@@ -133,20 +133,20 @@ abstract class Gutenberg_Handler {
 	 * @return void
 	 */
 	public function load_editor( $textarea, $container = null ) {
-		$this->gutenberg = new GutenbergEverywhere_Editor();
+		$this->gutenberg = new BlocksEverywhere_Editor();
 		$this->gutenberg->load();
 
 		$asset_file = dirname( __DIR__ ) . '/build/index.asset.php';
 		$asset = file_exists( $asset_file ) ? require_once $asset_file : null;
 		$version = isset( $asset['version'] ) ? $asset['version'] : time();
 
-		$plugin = dirname( dirname( __FILE__ ) ) . '/gutenberg-everywhere.php';
+		$plugin = dirname( dirname( __FILE__ ) ) . '/blocks-everywhere.php';
 
-		wp_register_script( 'gutenberg-everywhere', plugins_url( 'build/index.js', $plugin ), [], $version, true );
-		wp_enqueue_script( 'gutenberg-everywhere' );
+		wp_register_script( 'blocks-everywhere', plugins_url( 'build/index.js', $plugin ), [], $version, true );
+		wp_enqueue_script( 'blocks-everywhere' );
 
-		wp_register_style( 'gutenberg-everywhere', plugins_url( 'build/style-index.css', $plugin ), [], $version );
-		wp_enqueue_style( 'gutenberg-everywhere' );
+		wp_register_style( 'blocks-everywhere', plugins_url( 'build/style-index.css', $plugin ), [], $version );
+		wp_enqueue_style( 'blocks-everywhere' );
 
 		// Settings for the editor
 		$settings = [
@@ -169,7 +169,7 @@ abstract class Gutenberg_Handler {
 			'editorType' => $this->get_editor_type(),
 		];
 
-		wp_localize_script( 'gutenberg-everywhere', 'wpGutenbergEverywhere', apply_filters( 'gutenberg_everywhere_editor_settings', $settings ) );
+		wp_localize_script( 'blocks-everywhere', 'wpBlocksEverywhere', apply_filters( 'blocks_everywhere_editor_settings', $settings ) );
 	}
 
 	public function can_show_admin_editor( $hook ) {

--- a/classes/iso-gutenberg.php
+++ b/classes/iso-gutenberg.php
@@ -3,7 +3,7 @@
 /**
  * Provides functions to load Gutenberg assets
  */
-class GutenbergEverywhere_Editor {
+class BlocksEverywhere_Editor {
 	/**
 	 * Constructor
 	 */

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "automattic/gutenberg-everywhere",
+    "name": "automattic/blocks-everywhere",
 	"description": "Puts Gutenberg everywhere it can - bbPress, comments, and BuddyPress.",
     "require": {
 		"php": "7.4.*"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "gutenberg-everywhere",
+	"name": "blocks-everywhere",
 	"version": "1.4.2",
 	"description": "Gutenberg in WordPress comments, admin pages, bbPress, and BuddyPress.",
 	"main": "src/index.js",
@@ -7,7 +7,7 @@
 		"start": "wp-scripts start",
 		"build": "wp-scripts build && ./bin/lintfix.sh",
 		"release": "yarn build && rm -rf release && mkdir -p release && cp -R *.php readme.txt *.png build LICENSE.md classes release",
-		"dist": "yarn release && rm -rf dist && mkdir dist && mv release gutenberg-everywhere && zip gutenberg-everywhere.zip -r gutenberg-everywhere && mv gutenberg-everywhere release && mv gutenberg-everywhere.zip dist && release-it",
+		"dist": "yarn release && rm -rf dist && mkdir dist && mv release blocks-everywhere && zip blocks-everywhere.zip -r blocks-everywhere && mv blocks-everywhere release && mv blocks-everywhere.zip dist && release-it",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
 		"lint:php": "composer run-script lint"
@@ -40,7 +40,7 @@
 		"github": {
 			"release": true,
 			"assets": [
-				"dist/gutenberg-everywhere.zip"
+				"dist/blocks-everywhere.zip"
 			]
 		},
 		"npm": false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blocks-everywhere",
-	"version": "1.4.2",
+	"version": "1.6.0",
 	"description": "Gutenberg in WordPress comments, admin pages, bbPress, and BuddyPress.",
 	"main": "src/index.js",
 	"scripts": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -64,7 +64,7 @@
 
 	<!-- Overrides -->
 	<file>classes/</file>
-	<file>gutenberg-everywhere.php</file>
+	<file>blocks-everywhere.php</file>
 
 	<exclude-pattern>build/</exclude-pattern>
 	<exclude-pattern>dist/</exclude-pattern>
@@ -77,7 +77,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="gutenberg-everywhere"/>
+				<element value="blocks-everywhere"/>
 			</property>
 		</properties>
 	</rule>

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Stable tag: trunk
 Requires PHP: 5.6
 License: GPLv3
 
-Puts Gutenberg everywhere it can - bbPress, comments, and BuddyPress.
+Puts the Gutenberg block editor everywhere it can - bbPress, comments, and BuddyPress.
 
 == Description ==
 
@@ -26,7 +26,7 @@ The condition of the Gutenberg replacements are:
 - comments - alright
 - BuddyPress - needs a lot of work
 
-Gutenberg Everywhere is developed on Github at https://github.com/Automattic/gutenberg-everywhere
+Blocks Everywhere is developed on Github at https://github.com/Automattic/blocks-everywhere
 
 == Caveats ==
 
@@ -40,27 +40,30 @@ The loading of Gutenberg will also increase the page size of any page it is load
 
 == Usage ==
 
-To enable Gutenberg Everywhere you need to add the relevant `define` to `wp-config.php`:
+To enable Blocks Everywhere you need to add the relevant `define` to `wp-config.php`:
 
-`define( 'GUTENBERG_EVERYWHERE_COMMENTS', true );`
-`define( 'GUTENBERG_EVERYWHERE_BBPRESS', true );`
-`define( 'GUTENBERG_EVERYWHERE_BUDDYPRESS', true );`
+`define( 'BLOCKS_EVERYWHERE_COMMENTS', true );`
+`define( 'BLOCKS_EVERYWHERE_BBPRESS', true );`
+`define( 'BLOCKS_EVERYWHERE_BUDDYPRESS', true );`
 
-You can also use the WordPress filter `gutenberg_everywhere_comments`, `gutenberg_everywhere_bbpress`, and `gutenberg_everywhere_buddypress`.
+You can also use the WordPress filter `blocks_everywhere_comments`, `blocks_everywhere_bbpress`, and `blocks_everywhere_buddypress`.
 
 == Installation ==
 
 The plugin is simple to install:
 
-1. Download `gutenberg-everywhere.zip`
+1. Download `blocks-everywhere.zip`
 1. Unzip
-1. Upload `gutenberg-everywhere` directory to your `/wp-content/plugins` directory
+1. Upload `blocks-everywhere` directory to your `/wp-content/plugins` directory
 1. Go to the plugin management page and enable the plugin
 
 == Screenshots ==
 
 1. Gutenberg in a comment form
 2. Gutenberg when editing a comment
+
+= 1.6.0 =
+* Rename to Blocks Everywhere
 
 = 1.5.0 =
 * Further tweak the loading so handlers are not enabled by default

--- a/src/index.js
+++ b/src/index.js
@@ -112,17 +112,17 @@ function createEditor( container, textarea, settings ) {
 domReady( () => {
 	apiFetch.use( removeNullPostFromFileUploadMiddleware );
 
-	document.querySelectorAll( wpGutenbergEverywhere.saveTextarea ).forEach( ( node ) => {
+	document.querySelectorAll( wpBlocksEverywhere.saveTextarea ).forEach( ( node ) => {
 		let container;
 
 		// Prefer enclosing containers, so check if one exists outside.
-		const outerContainerNode = node.closest( wpGutenbergEverywhere.container );
+		const outerContainerNode = node.closest( wpBlocksEverywhere.container );
 		if ( outerContainerNode ) {
 			container = createContainer( node, outerContainerNode );
 		} else {
-			container = createContainer( node, document.querySelector( wpGutenbergEverywhere.container ) );
+			container = createContainer( node, document.querySelector( wpBlocksEverywhere.container ) );
 		}
 
-		createEditor( container, node, wpGutenbergEverywhere );
+		createEditor( container, node, wpBlocksEverywhere );
 	} );
 } );

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,5 +1,5 @@
 // Admin editor
-.gutenberg-everywhere {
+.blocks-everywhere {
 	margin-bottom: 30px;
 
 	// Hide the original textarea


### PR DESCRIPTION
Gutenberg is a protected plugin name, so lets go with Blocks Everywhere.

The `resources` will need to be updated to match.