### PR TITLE
Prevent submit buttons triggering parent form

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,10 @@ The plugin is simple to install:
 
 == Changelog ==
 
+= 1.9.0 =
+* Increase minimum editor size
+* Prevent editor buttons accidentally triggering a page submit
+
 = 1.8.0 =
 * Use .min in JS filename so it matches WP recommendations
 * Add a check for queuing media, for sites that need to do custom setups.

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,21 @@ function createEditor( container, textarea, settings ) {
 	);
 }
 
+// If the container is inside a form then we need insulate button clicks inside the editor from propagating out into the form
+// This is because a lot of Gutenberg buttons don't set a 'type', and so default to 'submit'
+function insulateForm( container ) {
+	const form = container.closest( 'form' );
+
+	if ( form ) {
+		form.addEventListener( 'submit', ( ev ) => {
+			if ( ev.submitter && ev.submitter.closest( '.iso-editor' ) ) {
+				ev.stopPropagation();
+				ev.preventDefault();
+			}
+		} );
+	}
+}
+
 domReady( () => {
 	apiFetch.use( removeNullPostFromFileUploadMiddleware );
 
@@ -123,6 +138,7 @@ domReady( () => {
 			container = createContainer( node, document.querySelector( wpBlocksEverywhere.container ) );
 		}
 
+		insulateForm( container );
 		createEditor( container, node, wpBlocksEverywhere );
 	} );
 } );


### PR DESCRIPTION
Some buttons in Gutenberg have no type and default to ‘submit’ if the editor is inside a form. This causes them to submit the page.
