### PR TITLE
Process blocks within `bbp_get_topic_content()`.

### DIFF
--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -24,6 +24,13 @@ class bbPress extends Handler {
 			8
 		);
 		add_filter(
+			'bbp_get_topic_content',
+			function( $content ) {
+				return $this->do_blocks( $content, 'bbp_get_topic_content' );
+			},
+			8
+		);
+		add_filter(
 			'bbp_get_reply_content',
 			function( $content ) {
 				return $this->do_blocks( $content, 'bbp_get_reply_content' );


### PR DESCRIPTION
When bbPress topics contain blocks, it doesn't appear like `do_blocks()` is being run on the content, causing the Block HTML comments to be rendered as `<p><!-- wp:paragraph --></p>`.