### PR TITLE
Add block processing to bbPress blocks

### DIFF
--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -77,7 +77,7 @@ class bbPress extends Handler {
 		$reply = wp_specialchars_decode( strip_tags( $reply ), ENT_QUOTES );
 
 		// Replace the original message
-		return preg_replace( '@<!--.*-->@s', $reply, $content );
+		return preg_replace( '@<!--.*-->@s', trim( $reply ), $content );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,12 @@ To enable back-end editing in bbPress:
 
 Or use the filter `blocks_everywhere_admin`. Back-end editing is restricted to users with the `manage_options` capability (can be changed with the `blocks_everywhere_admin_cap` filter).
 
+To enable conversion of blocks in email:
+
+`define( 'BLOCKS_EVERYWHERE_EMAIL', true );`
+
+Or use the filter `blocks_everywhere_email`.
+
 == Problems ==
 
 Gutenberg outputs HTML content and this may be affected by KSES (WordPress HTML sanitisation). The default sanitisation should work fine with the default blocks, however you may run into problems if you are using different blocks or have customised permission levels.
@@ -71,6 +77,9 @@ The plugin is simple to install:
 2. Gutenberg when editing a comment
 
 == Changelog ==
+
+= 1.10.0 =
+* Process blocks in bbPress notification emails
 
 = 1.9.0 =
 * Increase minimum editor size


### PR DESCRIPTION
Experimental block processing for bbPress notification emails.

Current technique is to use `bbp_subscription_mail_message` to replace the content in the email with a blockified version.

It also does a bit of markdown-lite conversion. Lists are prefixed with an asterisk, quotes a `>`, and bold is starred.

![image](https://user-images.githubusercontent.com/1277682/204280144-d52c237d-e396-40d4-ac4e-2d37878cd75b.png)
![image](https://user-images.githubusercontent.com/1277682/204280183-1498a0f0-edac-400f-a258-8054a08b0c5e.png)

See #40

There may be a better way of doing this.