### PR TITLE
Disable most of the TinyMCE buttons

### DIFF
--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -15,6 +15,20 @@ class Editor {
 
 		add_action( 'wp_footer', [ $this, 'wp_add_iframed_editor_assets_html' ], 20 );
 		add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
+		add_filter( 'tiny_mce_before_init', [ $this, 'tiny_mce_before_init' ] );
+	}
+
+	/**
+	 * Restrict TinyMCE to the basics
+	 *
+	 * @param array $settings TinyMCE settings.
+	 * @return array
+	 */
+	public function tiny_mce_before_init( $settings ) {
+		$settings['toolbar1'] = 'bold,italic,bullist,numlist,blockquote';
+		$settings['toolbar2'] = 'pastetext,removeformat,undo,redo';
+
+		return $settings;
 	}
 
 	/**

--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -15,7 +15,6 @@ class Editor {
 
 		add_action( 'wp_footer', [ $this, 'wp_add_iframed_editor_assets_html' ], 20 );
 		add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
-		add_filter( 'tiny_mce_before_init', [ $this, 'tiny_mce_before_init' ] );
 	}
 
 	/**
@@ -25,8 +24,8 @@ class Editor {
 	 * @return array
 	 */
 	public function tiny_mce_before_init( $settings ) {
-		$settings['toolbar1'] = 'bold,italic,bullist,numlist,blockquote';
-		$settings['toolbar2'] = 'pastetext,removeformat,undo,redo';
+		$settings['toolbar1'] = 'bold,italic,bullist,numlist,blockquote,pastetext,removeformat,undo,redo';
+		$settings['toolbar2'] = '';
 
 		return $settings;
 	}
@@ -42,6 +41,9 @@ class Editor {
 		global $post;
 
 		$this->load_extra_blocks();
+
+		// Restrict tinymce buttons
+		add_filter( 'tiny_mce_before_init', [ $this, 'tiny_mce_before_init' ] );
 
 		// Gutenberg scripts
 		wp_enqueue_script( 'wp-block-library' );


### PR DESCRIPTION
TinyMCE loads a lot of formatting tools that aren't available when editing on bbPress or other systems. TinyMCE will be used when editing old content.

This PR disables most of the toolbar buttons.

Fixes #44

![image](https://user-images.githubusercontent.com/1277682/204303126-a220c5be-e18b-498c-bd04-2bcbe3649ebc.png)
