### PR TITLE
bbPress KSES

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 <img width="1280" alt="110600033-c625d880-8183-11eb-9609-70ab7390c0d9" src="/resources/banner-1544x500.png">
 
-Gutenberg in WordPress comments, admin pages, bbPress, and BuddyPress.
+Switches the default WordPress editor for comments, bbPress, and BuddyPress to use Gutenberg. These can now use a richer set of editing tools, as well as having access to the full power of Gutenberg blocks.
 
-Features:
+Admin moderation is also upgraded to use Gutenberg, and blocks are processed on the front end.
 
-- list of blocks is determined by the list of allowed tags
-- block processing is run before displaying any block content on the front-end
-- Gutenberg is used on the admin edit page
+For extra security the list of available blocks is determined by the allowed tags from WordPress.
 
-Gutenberg is not bundled and instead is side-loaded from WordPress.
+Gutenberg is not bundled and instead is side-loaded from WordPress. For better compatibility you should use the plugin version of Gutenberg, which is typically several versions ahead of the one included in WordPress.
 
-Note that this is still experimental, and may require additional work to fit in with your theme of choice.
+The condition of the Gutenberg replacements are:
+- bbPress - good (requires bbPress 2.6+)
+- comments - alright
+- BuddyPress - needs a lot of work
 
 The plugin uses the [Isolated Block Editor](https://github.com/Automattic/isolated-block-editor/). This can also be found in:
 
@@ -25,11 +26,65 @@ Blocks Everywhere can be downloaded from WordPress.org:
 
 https://wordpress.org/plugins/blocks-everywhere/
 
-## Caveats
+### Caveats
 
-- The editor loads on every page where it is used. It may be performant to load it on-click.
-- There may be additional CSS needed to fully blend in with the chosen theme.
-- This assumes that `wp_kses` and Gutenberg will take care of any security issues for comments. This combination is untested by core.
+Gutenberg is placed directly on the page along with your post, forum, etc. This means the contents of the editor will look like the page they will appear on. However, it also means that styles from the page may affect the editor.
+
+Currently we don't have a perfect way of seperating these styles and it is possible that styles from the page or from Gutenberg may affect the other. If you are using this plugin then it is expected that you will be able to fix any differences as appropriate for your site.
+
+The loading of Gutenberg will also increase the page size of any page it is loaded on. You should be aware of this and willing to accept this in the context of your site.
+
+### Usage
+
+To enable Blocks Everywhere you need to add the relevant `define` to `wp-config.php`:
+
+```php
+define( 'BLOCKS_EVERYWHERE_COMMENTS', true );
+define( 'BLOCKS_EVERYWHERE_BBPRESS', true );
+define( 'BLOCKS_EVERYWHERE_BUDDYPRESS', true );
+```
+
+You can also use the WordPress filter `blocks_everywhere_comments`, `blocks_everywhere_bbpress`, and `blocks_everywhere_buddypress`.
+
+To enable back-end editing in bbPress:
+
+`define( 'BLOCKS_EVERYWHERE_ADMIN', true );`
+
+Or use the filter `blocks_everywhere_admin`. Back-end editing is restricted to users with the `manage_options` capability (can be changed with the `blocks_everywhere_admin_cap` filter).
+
+To enable conversion of blocks in email:
+
+`define( 'BLOCKS_EVERYWHERE_EMAIL', true );`
+
+Or use the filter `blocks_everywhere_email`.
+
+# Using Content Embed block
+
+Content Embed block uses REST API to fetch content to be embedded. This means that site contains bbPress topics to embed should have topic REST API enabled.
+
+Blocks Everywhere enables topic REST API on its own, so if the site with bbPress have this plugin installed and configured, its topics can be embedded.
+
+To enable Content Embed block in the editor, pass these settings to `blocks_everywhere_editor_settings` filter:
+```
+	add_filter( 'blocks_everywhere_editor_settings', function( $settings ) {
+        $settings['iso']['blocks']['allowBlocks'][] = 'blocks-everywhere/support-content';
+		return $settings;
+	} );
+```
+
+To enable REST API for forum topics, use next filters:
+```
+add_filter( 'blocks_everywhere_admin', '__return_true' );
+add_filter( 'blocks_everywhere_admin_cap', '__return_empty_string' );
+```
+
+REST API is only used when creating content embed and not used to view it. So `blocks_everywhere_admin_cap` can return specific capability to limit users who will have access to API.
+
+### KSES
+
+Gutenberg outputs HTML content and this may be affected by KSES (WordPress HTML sanitisation), as well as other functions.
+
+The plugin provides some modifications to this so it works fine with basic blocks. You may run into problems if you are using different blocks or have customised permission levels.
 
 ## Building
 

--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -12,9 +12,30 @@ class Editor {
 	public function __construct() {
 		add_action( 'template_redirect', [ $this, 'setup_media' ] );
 		add_filter( 'block_editor_settings_all', [ $this, 'block_editor_settings_all' ] );
-
 		add_action( 'wp_footer', [ $this, 'wp_add_iframed_editor_assets_html' ], 20 );
 		add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
+		add_filter( 'wp_theme_json_data_theme', [ $this, 'wp_theme_json_data_theme' ] );
+	}
+
+	/**
+	 * Provide theme.json
+	 *
+	 * @param \WP_Theme_JSON_Data_Gutenberg $json JSON.
+	 * @return \WP_Theme_JSON_Data_Gutenberg
+	 */
+	public function wp_theme_json_data_theme( $json ) {
+		$theme = new \WP_Theme_JSON_Data_Gutenberg(
+			[
+				'version' => 2,
+				'settings' => [
+					'typography' => [
+						'dropCap' => false,
+					],
+				],
+			]
+		);
+
+		return $theme;
 	}
 
 	/**

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -105,7 +105,7 @@ abstract class Handler {
 	 *
 	 * @return string[]
 	 */
-	private function get_allowed_blocks() {
+	protected function get_allowed_blocks() {
 		global $allowedtags;
 
 		$allowed = [ 'core/paragraph', 'core/list', 'core/code', 'core/list-item' ];
@@ -129,6 +129,88 @@ abstract class Handler {
 		}
 
 		return apply_filters( 'blocks_everywhere_allowed_blocks', array_unique( $allowed ), $this->get_editor_type() );
+	}
+
+	/**
+	 * Modify KSES filters to match the allowed blocks
+	 *
+	 * @param array $tags
+	 * @return void
+	 */
+	public function get_kses_for_allowed_blocks( array $tags ) {
+		$allowed = $this->get_allowed_blocks();
+
+		if ( in_array( 'core/paragraph', $allowed, true ) ) {
+			$tags['p'] = [
+				'class' => [
+					'has-text-align-center',
+					'has-text-align-left',
+					'has-text-align-right',
+				],
+			];
+		}
+
+		if ( in_array( 'core/code', $allowed, true ) ) {
+			if ( ! isset( $tags['pre'] ) ) {
+				$tags['pre'] = [];
+			}
+
+			$tags['pre']['class'] = [
+				'wp-block-code',
+			];
+		}
+
+		if ( in_array( 'core/quote', $allowed, true ) ) {
+			if ( ! isset( $tags['blockquote'] ) ) {
+				$tags['blockquote'] = [];
+			}
+
+			$tags['blockquote']['class'] = [
+				'wp-block-quote',
+				'is-style-plain',
+			];
+		}
+
+		if ( in_array( 'core/image', $allowed, true ) || in_array( 'core/quote', $allowed, true ) ) {
+			$tags['figure'] = [
+				'class' => [
+					'wp-block-image',
+					'size-large',
+					'size-medium',
+					'size-small',
+					'alignright',
+					'alignleft',
+					'aligncenter',
+					'is-resized',
+				],
+			];
+			$tags['figcaption'] = [
+				'class' => [
+					'wp-element-caption',
+				],
+			];
+		}
+
+		if ( in_array( 'core/embed', $allowed, true ) ) {
+			if ( ! isset( $tags['figure'] ) ) {
+				$tags['figure'] = [];
+			}
+
+			$tags['figure']['class'] = true;
+			$tags['div'] = [
+				'class' => 'wp-block-embed__wrapper',
+			];
+		}
+
+		// General formatting
+		$tags['strike'] = [];
+		$tags['cite'] = true;
+		$tags['kbd'] = true;
+		$tags['mark'] = [
+			'class' => true,
+		];
+
+		return $tags;
 	}
 
 	/**

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -141,13 +141,7 @@ abstract class Handler {
 		$allowed = $this->get_allowed_blocks();
 
 		if ( in_array( 'core/paragraph', $allowed, true ) ) {
-			$tags['p'] = [
-				'class' => [
-					'has-text-align-center',
-					'has-text-align-left',
-					'has-text-align-right',
-				],
-			];
+			$tags['p'] = [ 'class' => true ];
 		}
 
 		if ( in_array( 'core/code', $allowed, true ) ) {
@@ -155,9 +149,7 @@ abstract class Handler {
 				$tags['pre'] = [];
 			}
 
-			$tags['pre']['class'] = [
-				'wp-block-code',
-			];
+			$tags['pre']['class'] = true;
 		}
 
 		if ( in_array( 'core/quote', $allowed, true ) ) {
@@ -165,30 +157,12 @@ abstract class Handler {
 				$tags['blockquote'] = [];
 			}
 
-			$tags['blockquote']['class'] = [
-				'wp-block-quote',
-				'is-style-plain',
-			];
+			$tags['blockquote']['class'] = true;
 		}
 
 		if ( in_array( 'core/image', $allowed, true ) || in_array( 'core/quote', $allowed, true ) ) {
-			$tags['figure'] = [
-				'class' => [
-					'wp-block-image',
-					'size-large',
-					'size-medium',
-					'size-small',
-					'alignright',
-					'alignleft',
-					'aligncenter',
-					'is-resized',
-				],
-			];
-			$tags['figcaption'] = [
-				'class' => [
-					'wp-element-caption',
-				],
-			];
+			$tags['figure'] = [ 'class' => true ];
+			$tags['figcaption'] = [ 'class' => true ];
 		}
 
 		if ( in_array( 'core/embed', $allowed, true ) ) {
@@ -197,18 +171,14 @@ abstract class Handler {
 			}
 
 			$tags['figure']['class'] = true;
-			$tags['div'] = [
-				'class' => 'wp-block-embed__wrapper',
-			];
+			$tags['div'] = [ 'class' => true ];
 		}
 
 		// General formatting
 		$tags['strike'] = [];
 		$tags['cite'] = true;
 		$tags['kbd'] = true;
-		$tags['mark'] = [
-			'class' => true,
-		];
+		$tags['mark'] = [ 'class' => true ];
 
 		return $tags;
 	}
@@ -289,6 +259,12 @@ abstract class Handler {
 		wp_localize_script( $name, 'wpBlocksEverywhere', $settings );
 	}
 
+	/**
+	 * Callback to show admin editor
+	 *
+	 * @param string $hook Hook.
+	 * @return boolean
+	 */
 	public function can_show_admin_editor( $hook ) {
 		return false;
 	}

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -57,7 +57,10 @@ class bbPress extends Handler {
 
 		add_action( 'bbp_head', [ $this, 'bbp_head' ] );
 
-		$this->setup_kses();
+		// If the user doesn't have unfiltered_html then we need to modify KSES to allow blocks
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			$this->setup_kses();
+		}
 	}
 
 	private function setup_kses() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blocks-everywhere",
-	"version": "1.9.0",
+	"version": "1.10.0",
 	"description": "Gutenberg in WordPress comments, admin pages, bbPress, and BuddyPress.",
 	"main": "src/index.js",
 	"scripts": {
@@ -15,7 +15,7 @@
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
 	"devDependencies": {
-		"@babel/core": "^7.20.2",
+		"@babel/core": "^7.20.5",
 		"@babel/preset-env": "^7.20.2",
 		"@babel/preset-react": "^7.18.6",
 		"@types/eslint": "^8.4.10",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: johnny5, automattic
 Tags: gutenberg, comments, bbpress, buddypress
 Requires at least: 5.8
 Tested up to: 6.1
-Stable tag: 1.9.0
+Stable tag: 1.10.0
 Requires PHP: 5.6
 License: GPLv3
 
@@ -106,6 +106,8 @@ The plugin is simple to install:
 
 = 1.10.0 =
 * Process blocks in bbPress notification emails
+* Add a Content Embed block to allow embedding of forum posts and support pages
+* Provide basic bbPress KSES filtering so blocks can be added by lower capability users
 
 = 1.9.0 =
 * Increase minimum editor size

--- a/readme.txt
+++ b/readme.txt
@@ -20,7 +20,7 @@ For extra security the list of available blocks is determined by the allowed tag
 Gutenberg is not bundled and instead is side-loaded from WordPress. For better compatibility you should use the plugin version of Gutenberg, which is typically several versions ahead of the one included in WordPress.
 
 The condition of the Gutenberg replacements are:
-- bbPress - pretty good (requires bbPress 2.6+)
+- bbPress - good (requires bbPress 2.6+)
 - comments - alright
 - BuddyPress - needs a lot of work
 
@@ -63,6 +63,7 @@ Or use the filter `blocks_everywhere_email`.
 == Using Content Embed block ==
 
 Content Embed block uses REST API to fetch content to be embedded. This means that site contains bbPress topics to embed should have topic REST API enabled.
+
 Blocks Everywhere enables topic REST API on its own, so if the site with bbPress have this plugin installed and configured, its topics can be embedded.
 
 To enable Content Embed block in the editor, pass these settings to `blocks_everywhere_editor_settings` filter:
@@ -81,9 +82,11 @@ add_filter( 'blocks_everywhere_admin_cap', '__return_empty_string' );
 
 REST API is only used when creating content embed and not used to view it. So `blocks_everywhere_admin_cap` can return specific capability to limit users who will have access to API.
 
-== Problems ==
+== KSES ==
 
-Gutenberg outputs HTML content and this may be affected by KSES (WordPress HTML sanitisation). The default sanitisation should work fine with the default blocks, however you may run into problems if you are using different blocks or have customised permission levels.
+Gutenberg outputs HTML content and this may be affected by KSES (WordPress HTML sanitisation) and other sanitisation.
+
+The plugin provides some modifications to this so it works fine with basic blocks. You may run into problems if you are using different blocks or have customised permission levels.
 
 == Installation ==
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,8 +124,24 @@ function insulateForm( container ) {
 	}
 }
 
+function modifyBlocks( settings, name ) {
+	return {
+		...settings,
+		supports: {
+			...settings.supports,
+			customClassName: false,
+			anchor: false,
+			html: false,
+			color: false,
+		},
+	};
+}
+
 domReady( () => {
 	apiFetch.use( removeNullPostFromFileUploadMiddleware );
+
+	// Modify any blocks we need to
+	wp.hooks.addFilter( 'blocks.registerBlockType', 'blocks-everywhere/modify-blocks', modifyBlocks );
 
 	document.querySelectorAll( wpBlocksEverywhere.saveTextarea ).forEach( ( node ) => {
 		let container;

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,21 +165,21 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/core@^7.20.2":
-  version "7.20.2"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.2.tgz#8dc9b1620a673f92d3624bd926dc49a52cf25b92"
-  integrity sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==
+"@babel/core@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.5.tgz#45e2114dc6cd4ab167f81daf7820e8fa1250d113"
+  integrity sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.20.2"
+    "@babel/generator" "^7.20.5"
     "@babel/helper-compilation-targets" "^7.20.0"
     "@babel/helper-module-transforms" "^7.20.2"
-    "@babel/helpers" "^7.20.1"
-    "@babel/parser" "^7.20.2"
+    "@babel/helpers" "^7.20.5"
+    "@babel/parser" "^7.20.5"
     "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.20.1"
-    "@babel/types" "^7.20.2"
+    "@babel/traverse" "^7.20.5"
+    "@babel/types" "^7.20.5"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -231,12 +231,21 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/generator@^7.20.1", "@babel/generator@^7.20.2":
+"@babel/generator@^7.20.1":
   version "7.20.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.4.tgz#4d9f8f0c30be75fd90a0562099a26e5839602ab8"
   integrity sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==
   dependencies:
     "@babel/types" "^7.20.2"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.5.tgz#cb25abee3178adf58d6814b68517c62bdbfdda95"
+  integrity sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==
+  dependencies:
+    "@babel/types" "^7.20.5"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -734,14 +743,14 @@
     "@babel/traverse" "^7.18.6"
     "@babel/types" "^7.18.6"
 
-"@babel/helpers@^7.20.1":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.1.tgz#2ab7a0fcb0a03b5bf76629196ed63c2d7311f4c9"
-  integrity sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==
+"@babel/helpers@^7.20.5":
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.6.tgz#e64778046b70e04779dfbdf924e7ebb45992c763"
+  integrity sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==
   dependencies:
     "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.20.1"
-    "@babel/types" "^7.20.0"
+    "@babel/traverse" "^7.20.5"
+    "@babel/types" "^7.20.5"
 
 "@babel/highlight@^7.14.5":
   version "7.14.5"
@@ -781,10 +790,15 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.6.tgz#b923430cb94f58a7eae8facbffa9efd19130e7f8"
   integrity sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==
 
-"@babel/parser@^7.20.1", "@babel/parser@^7.20.2":
+"@babel/parser@^7.20.1":
   version "7.20.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.3.tgz#5358cf62e380cf69efcb87a7bb922ff88bfac6e2"
   integrity sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==
+
+"@babel/parser@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.5.tgz#7f3c7335fe417665d929f34ae5dceae4c04015e8"
+  integrity sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1973,6 +1987,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.5.tgz#78eb244bea8270fdda1ef9af22a5d5e5b7e57133"
+  integrity sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.5"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.20.5"
+    "@babel/types" "^7.20.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.14.8", "@babel/types@^7.14.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.14.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.9.tgz#f2b19c3f2f77c5708d67fe8f6046e9cea2b5036d"
@@ -2011,6 +2041,15 @@
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.2.tgz#67ac09266606190f496322dbaff360fdaa5e7842"
   integrity sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.5.tgz#e206ae370b5393d94dfd1d04cd687cace53efa84"
+  integrity sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"


### PR DESCRIPTION
Allows block markup to survive bbPress, as well as maps Gutenberg blocks to a set of KSES rules. Together this will allow a non-administrator account to post content without it being mangled in some way.

Additionally the following Gutenberg features have been disabled as they're not needed in the situations this plugin runs in:
- typography controls
- colours
- drop caps
- custom class names
- anchors

Based on code by @dd32 