### PR TITLE
Fix code blocks for admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,21 +58,23 @@ To enable conversion of blocks in email:
 
 Or use the filter `blocks_everywhere_email`.
 
-# Using Content Embed block
+### Using Content Embed block
 
 Content Embed block uses REST API to fetch content to be embedded. This means that site contains bbPress topics to embed should have topic REST API enabled.
 
 Blocks Everywhere enables topic REST API on its own, so if the site with bbPress have this plugin installed and configured, its topics can be embedded.
 
 To enable Content Embed block in the editor, pass these settings to `blocks_everywhere_editor_settings` filter:
+
 ```
-	add_filter( 'blocks_everywhere_editor_settings', function( $settings ) {
-        $settings['iso']['blocks']['allowBlocks'][] = 'blocks-everywhere/support-content';
-		return $settings;
-	} );
+add_filter( 'blocks_everywhere_editor_settings', function( $settings ) {
+	$settings['iso']['blocks']['allowBlocks'][] = 'blocks-everywhere/support-content';
+	return $settings;
+} );
 ```
 
 To enable REST API for forum topics, use next filters:
+
 ```
 add_filter( 'blocks_everywhere_admin', '__return_true' );
 add_filter( 'blocks_everywhere_admin_cap', '__return_empty_string' );
@@ -96,7 +98,7 @@ Or:
 
 `yarn build`
 
-## Releasing
+### Releasing
 
 Run:
 
@@ -104,7 +106,7 @@ Run:
 
 The plugin will be available in the `release` directory.
 
-## Distribution
+### Distribution
 
 Run:
 

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -57,6 +57,12 @@ class bbPress extends Handler {
 
 		add_action( 'bbp_head', [ $this, 'bbp_head' ] );
 
+		// Required to prevent code blocks being reverted from `<code>` to backtics in editor, breaking blocks.
+		// Also helps stop bbp_code_trick_reverse remove a trailing </p>
+		remove_filter( 'bbp_get_form_forum_content', 'bbp_code_trick_reverse' );
+		remove_filter( 'bbp_get_form_topic_content', 'bbp_code_trick_reverse' );
+		remove_filter( 'bbp_get_form_reply_content', 'bbp_code_trick_reverse' );
+
 		// If the user doesn't have unfiltered_html then we need to modify KSES to allow blocks
 		if ( ! current_user_can( 'unfiltered_html' ) ) {
 			$this->setup_kses();
@@ -73,12 +79,6 @@ class bbPress extends Handler {
 	 * @return void
 	 */
 	private function setup_kses() {
-		// Required to prevent code blocks being reverted from `<code>` to backtics in editor, breaking blocks.
-		// Also helps stop bbp_code_trick_reverse remove a trailing </p>
-		remove_filter( 'bbp_get_form_forum_content', 'bbp_code_trick_reverse' );
-		remove_filter( 'bbp_get_form_topic_content', 'bbp_code_trick_reverse' );
-		remove_filter( 'bbp_get_form_reply_content', 'bbp_code_trick_reverse' );
-
 		// Allow block comments in content
 		foreach (
 			[

--- a/readme.txt
+++ b/readme.txt
@@ -68,10 +68,10 @@ Blocks Everywhere enables topic REST API on its own, so if the site with bbPress
 
 To enable Content Embed block in the editor, pass these settings to `blocks_everywhere_editor_settings` filter:
 ```
-	add_filter( 'blocks_everywhere_editor_settings', function( $settings ) {
-        $settings['iso']['blocks']['allowBlocks'][] = 'blocks-everywhere/support-content';
-		return $settings;
-	} );
+add_filter( 'blocks_everywhere_editor_settings', function( $settings ) {
+	$settings['iso']['blocks']['allowBlocks'][] = 'blocks-everywhere/support-content';
+	return $settings;
+} );
 ```
 
 To enable REST API for forum topics, use next filters:


### PR DESCRIPTION
The `bbp_code_trick_reverse` changes need to run for everyone, not just subscribers. WIthout this code blocks are converted to back ticks