### PR TITLE
Fix/content embed images

### DIFF
--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -222,6 +222,7 @@ abstract class Handler {
 			'saveTextarea' => $textarea,
 			'container' => $container,
 			'editorType' => $this->get_editor_type(),
+			'pluginsUrl' => plugins_url()
 		];
 
 		$settings = apply_filters( 'blocks_everywhere_editor_settings', $default_settings );

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -222,7 +222,7 @@ abstract class Handler {
 			'saveTextarea' => $textarea,
 			'container' => $container,
 			'editorType' => $this->get_editor_type(),
-			'pluginsUrl' => plugins_url()
+			'pluginsUrl' => plugins_url( '', __DIR__ )
 		];
 
 		$settings = apply_filters( 'blocks_everywhere_editor_settings', $default_settings );

--- a/src/support-content-block/wordpress-icon.tsx
+++ b/src/support-content-block/wordpress-icon.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import classnames from 'classnames';
-import rasterizedIcon from './wordpress.png';
+import icon from './wordpress.png';
 
 export const WordPressIcon = () => {
+	// req param required to avoid adding it automatically thus breaking block parsing
+	const imgUrl = wpBlocksEverywhere.pluginsUrl + icon + '?m=1';
+
 	return (
-		<>
-			<div className={ classnames( 'be-support-content-wordpress-icon' ) }>
-				{ /* req param required to avoid adding it automatically thus breaking block parsing */ }
-				<img alt="WP" src={ rasterizedIcon + '?m=1' } />
-			</div>
-		</>
+		<div className={ classnames( 'be-support-content-wordpress-icon' ) }>
+			<img alt="WP" src={ imgUrl } />
+		</div>
 	);
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,1 +1,5 @@
 declare module '*.png';
+
+declare var wpBlocksEverywhere: {
+	pluginsUrl: string;
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const RemovePlugin = require('remove-files-webpack-plugin');
 defaultConfig.module.rules
 	.filter( ( r ) => r.type === 'asset/resource' )
 	.forEach( ( r ) => {
-		r.generator.publicPath = '/wp-content/plugins/blocks-everywhere/build/';
+		r.generator.publicPath = '/build/';
 	} );
 
 // Default @wordpress/scripts but output with .min in the filename


### PR DESCRIPTION
On WP.com, content embed logo image was not served from a CDN thus resulting in a broken view:
![image](https://user-images.githubusercontent.com/133608/205058105-b1d0e176-8951-47c8-815a-ab58c9aae6cd.png)

This PR adds `plugins_url()` before the image URL to fix the issue.

## How to test

Not sure how to test fully without deploying to production.
However, to verify it works on sandbox:
1. Open the editor
2. Add new content embed by pasting URL 'https://wordpress.com/support/domains/connect-existing-domain/'
3. Verify WordPress image is loaded.

