### PR TITLE
Fix/content embed style fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"dist": "yarn release && rm -rf dist && mkdir dist && mv release blocks-everywhere && zip blocks-everywhere.zip -r blocks-everywhere && mv blocks-everywhere release && mv blocks-everywhere.zip dist && release-it",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
-		"lint:php": "composer run-script lint"
+		"lint:php": "composer run-script lint",
+		"dev:sync": "yarn release && rsync -avz --delete release/ wpcom:public_html/wp-content/plugins/blocks-everywhere/"
 	},
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
 		"dist": "yarn release && rm -rf dist && mkdir dist && mv release blocks-everywhere && zip blocks-everywhere.zip -r blocks-everywhere && mv blocks-everywhere release && mv blocks-everywhere.zip dist && release-it",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
-		"lint:php": "composer run-script lint",
-		"dev:sync": "yarn release && rsync -avz --delete release/ wpcom:public_html/wp-content/plugins/blocks-everywhere/"
+		"lint:php": "composer run-script lint"
 	},
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,14 @@ add_filter( 'blocks_everywhere_admin_cap', '__return_empty_string' );
 
 REST API is only used when creating content embed and not used to view it. So `blocks_everywhere_admin_cap` can return specific capability to limit users who will have access to API.
 
+In order for Content Embed block from Blocks Everywhere to load post authors, it is required to enable author data in the topic REST API. To do it, use this filter
+```
+add_action( 'bbp_get_topic_post_type_supports', function( $supports ) {
+	$supports[] = 'author';
+	return $supports;
+} );
+```
+
 == KSES ==
 
 Gutenberg outputs HTML content and this may be affected by KSES (WordPress HTML sanitisation) and other sanitisation.

--- a/src/support-content-block/block.ts
+++ b/src/support-content-block/block.ts
@@ -126,6 +126,9 @@ export async function fetchForumTopicAttributes( url: string ): Promise< Support
 	};
 }
 
+/**
+ * Fetch author name via WP.com or WP REST API
+ */
 async function fetchForumTopicAuthor( userId: number, blog: string, isWpComApi: boolean ): Promise< string > {
 	const apiUrl = isWpComApi
 		? `https://public-api.wordpress.com/rest/v1.1/users/${ userId }`

--- a/src/support-content-block/block.ts
+++ b/src/support-content-block/block.ts
@@ -84,7 +84,7 @@ export async function fetchSupportPageAttributes( url: string ): Promise< Suppor
 		content = content.substring( 0, EMBED_CONTENT_MAXLENGTH );
 	}
 
-	return { url, isConfirmed: true, content, title, source: 'WordPress.com Guide', minutesToRead };
+	return { url, isConfirmed: true, content, title, source: 'WordPress.com Support', minutesToRead };
 }
 
 /**

--- a/src/support-content-block/block.ts
+++ b/src/support-content-block/block.ts
@@ -93,7 +93,7 @@ export async function fetchSupportPageAttributes( url: string ): Promise< Suppor
 export async function fetchForumTopicAttributes( url: string ): Promise< SupportContentBlockAttributes > {
 	const { blog, slug } = getForumTopicSlugFromUrl( url );
 
-	let isWpComApi = blog.endsWith( 'wordpress.com' );
+	const isWpComApi = blog.endsWith( 'wordpress.com' );
 
 	const apiUrl = isWpComApi
 		? `https://public-api.wordpress.com/wp/v2/sites/${ blog }/topic?slug=${ encodeURIComponent( slug ) }`
@@ -130,19 +130,23 @@ export async function fetchForumTopicAttributes( url: string ): Promise< Support
  * Fetch author name via WP.com or WP REST API
  */
 async function fetchForumTopicAuthor( userId: number, blog: string, isWpComApi: boolean ): Promise< string > {
-	const apiUrl = isWpComApi
-		? `https://public-api.wordpress.com/rest/v1.1/users/${ userId }`
-		: `https://${ blog }/wp-json/wp/v2/users/${ userId }`;
+	try {
+		const apiUrl = isWpComApi
+			? `https://public-api.wordpress.com/rest/v1.1/users/${ userId }`
+			: `https://${ blog }/wp-json/wp/v2/users/${ userId }`;
 
-	const response = await fetch( apiUrl );
+		const response = await fetch( apiUrl );
 
-	if ( ! response.ok ) {
-		return null;
+		if ( ! response.ok ) {
+			return null;
+		}
+
+		const user = await response.json();
+
+		return user.display_name || user.name;
+	} catch ( e ) {
+		return;
 	}
-
-	const user = await response.json();
-
-	return user.display_name || user.name;
 }
 
 /**

--- a/src/support-content-block/block.ts
+++ b/src/support-content-block/block.ts
@@ -28,6 +28,7 @@ export type SupportContentBlockAttributes = {
 	title: string;
 	content: string;
 	source: string;
+	sourceURL: string;
 	minutesToRead?: number | null;
 	likes?: number;
 	status?: string;
@@ -84,7 +85,15 @@ export async function fetchSupportPageAttributes( url: string ): Promise< Suppor
 		content = content.substring( 0, EMBED_CONTENT_MAXLENGTH );
 	}
 
-	return { url, isConfirmed: true, content, title, source: 'WordPress.com Support', minutesToRead };
+	return {
+		url,
+		isConfirmed: true,
+		content,
+		title,
+		source: 'WordPress.com Support',
+		sourceURL: 'https://wordpress.com/support/',
+		minutesToRead,
+	};
 }
 
 /**
@@ -120,7 +129,8 @@ export async function fetchForumTopicAttributes( url: string ): Promise< Support
 		content,
 		title,
 		author: topic.author ? await fetchForumTopicAuthor( topic.author, blog, isWpComApi ) : undefined,
-		source: 'WordPress.com Forums',
+		source: isWpComApi ? 'WordPress.com Forums' : `${ blog } Forums`,
+		sourceURL: `https://${ blog }`,
 		status: topic.status,
 		created: topic.date,
 	};

--- a/src/support-content-block/index.tsx
+++ b/src/support-content-block/index.tsx
@@ -39,6 +39,12 @@ registerBlockType( 'blocks-everywhere/support-content', {
 			source: 'text',
 			selector: '.be-support-content__link',
 		},
+		sourceURL: {
+			type: 'string',
+			source: 'attribute',
+			selector: '.be-support-content__link',
+			attribute: 'href',
+		},
 		minutesToRead: {
 			type: 'number',
 		},

--- a/src/support-content-block/support-content-embed.tsx
+++ b/src/support-content-block/support-content-embed.tsx
@@ -52,7 +52,7 @@ export const SupportContentEmbed = ( props: {
 			const startedby = sprintf(
 				/* translators: Person who created forum topic, eg: "Started by davidgonzalezwp" */
 				__( 'Started by %s', 'blocks-everywhere' ),
-				props.attributes.minutesToRead
+				props.attributes.author
 			);
 
 			return (

--- a/src/support-content-block/support-content-embed.tsx
+++ b/src/support-content-block/support-content-embed.tsx
@@ -94,7 +94,7 @@ export const SupportContentEmbed = ( props: {
 					<div className="be-support-content__source">
 						<InlineSkeleton hidden loaded={ loaded }>
 							{ createInterpolateElement( source, {
-								a: <a className="be-support-content__link" href={ props.attributes.url } />,
+								a: <a className="be-support-content__link" href={ props.attributes.sourceURL } />,
 							} ) }
 						</InlineSkeleton>
 					</div>

--- a/src/support-content-block/view.scss
+++ b/src/support-content-block/view.scss
@@ -118,7 +118,7 @@
 }
 
 // Override bbPress styles
-.bbp-reply-content a.be-support-content__link {
+.bbp-reply-content .be-support-content a.be-support-content__link {
 	text-decoration: none !important;
 
 	&:hover {

--- a/src/support-content-block/view.scss
+++ b/src/support-content-block/view.scss
@@ -21,6 +21,7 @@
 	padding: 29px 30px;
 	cursor: pointer;
 
+	position: relative;
 	display: flex;
 	gap: 16px;
 	flex-direction: column;


### PR DESCRIPTION
This PR fixes Content Embed issues mentioned in 118-gh-Automattic/lighthouse-forums#issuecomment-1333900588

Changes:
- loading topic author name via API
- layout fixes

To load the topic author it is required to expose the author ID via API. That is implemented in the Phab diff D94298

## Testing instructions

1. Update sandbox by running `yarn release` and then uploading `release/*` files 
2. Apply Phabricator diff D94298
3. Open the editor
4. Embed public forum topic
5. Verify it has author's name.
6. Embed a support page, and verify two embeds have different URLs
7. Verify links "in WordPress.com Forums" are not underlined until hovered
8. Verify link in the support page embed is labeled "in WordPress.com Support".