### PR TITLE
Fix is-pressed style

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A theme compatibility option is provided which might help. You can use this with
 
 `define( 'BLOCKS_EVERYWHERE_THEME_COMPAT', true );`
 
-Or using the filter `blocks_everywhere_email`.
+Or using the filter `blocks_everywhere_theme_compat`.
 
 It provides some overrides for common theme issues. However, it is generally better not to require overrides so if you are able to modify your theme and make CSS more specific then that is the best route.
 

--- a/bin/lintfix.sh
+++ b/bin/lintfix.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 sed "s/<?php /<?php\n\/\/ phpcs:ignore\n/" build/index.min.asset.php | sed "s/);/);\n/" > build/index.min.asset.php.new
 mv build/index.min.asset.php.new build/index.min.asset.php
+
+sed "s/<?php /<?php\n\/\/ phpcs:ignore\n/" build/support-content-editor.min.asset.php | sed "s/);/);\n/" > build/support-content-editor.min.asset.php.new
+mv build/support-content-editor.min.asset.php.new build/support-content-editor.min.asset.php
+
+sed "s/<?php /<?php\n\/\/ phpcs:ignore\n/" build/support-content-view.min.asset.php | sed "s/);/);\n/" > build/support-content-view.min.asset.php.new
+mv build/support-content-view.min.asset.php.new build/support-content-view.min.asset.php

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -108,7 +108,7 @@ abstract class Handler {
 	protected function get_allowed_blocks() {
 		global $allowedtags;
 
-		$allowed = [ 'core/paragraph', 'core/list', 'core/code', 'core/list-item' ];
+		$allowed = [ 'core/paragraph', 'core/list', 'core/list-item', 'core/code', 'core/list-item' ];
 		$convert = [
 			'blockquote' => 'core/quote',
 			'h1' => 'core/heading',
@@ -176,7 +176,8 @@ abstract class Handler {
 		}
 
 		// General formatting
-		$tags['strike'] = [];
+		$tags['strike'] = true;
+		$tags['s'] = true;
 		$tags['cite'] = true;
 		$tags['kbd'] = true;
 		$tags['mark'] = [ 'class' => true ];
@@ -204,6 +205,9 @@ abstract class Handler {
 				'sidebar' => [
 					'inserter' => false,
 					'inspector' => false,
+				],
+				'toolbar' => [
+					'navigation' => true,
 				],
 				'defaultPreferences' => [
 					'fixedToolbar' => true,

--- a/readme.txt
+++ b/readme.txt
@@ -68,7 +68,7 @@ A theme compatibility option is provided which might help. You can use this with
 
 `define( 'BLOCKS_EVERYWHERE_THEME_COMPAT', true );`
 
-Or using the filter `blocks_everywhere_email`.
+Or using the filter `blocks_everywhere_theme_compat`.
 
 It provides some overrides for common theme issues. However, it is generally better not to require overrides so if you are able to modify your theme and make CSS more specific then that is the best route.
 

--- a/src/theme-compat.scss
+++ b/src/theme-compat.scss
@@ -48,7 +48,7 @@
 		font-size: 13px !important;
 	}
 
-	button:not(:hover):not(:active):not(.has-background):not(.block-editor-inserter__toggle):not(.is-primary) {
+	button:not(:hover):not(:active):not(.has-background):not(.block-editor-inserter__toggle):not(.is-primary):not(.is-pressed):not(.block-list-appender__toggle) {
 		background-color: none;
 		color: #1e1e1e;
 	}


### PR DESCRIPTION
Fixes the `is-pressed` style in the toolbar, which was making toggle buttons black.

Also fixes a couple of build issues and allows the `s` tag.

Fixes #56