### PR TITLE
Add a bbPress editor filter for late decision about whether to show the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ To enable conversion of blocks in email:
 
 Or use the filter `blocks_everywhere_email`.
 
+To enable Gutenberg when editing bbPress forums, topics, and replies you can use:
+
+`define( 'BLOCKS_EVERYWHERE_BBPRESS_ADMIN', true );`
+
+Or use `blocks_everywhere_bbpress_admin`
+
 ### Theme compatibility
 
 Gutenberg is placed directly on the page along with your post, forum, etc. This means the contents of the editor will look like the page they will appear on. However, it also means that styles from the page may affect the editor.

--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Blocks Everywhere
 Description: Because somewhere is just not enough. Add Gutenberg to WordPress comments, bbPress forums, and BuddyPress streams. Also enables Gutenberg for comment & bbPress moderation.
-Version: 1.10.0
+Version: 1.11.0
 Author: Automattic
 Text Domain: 'blocks-everywhere'
 */
@@ -15,7 +15,7 @@ require_once __DIR__ . '/classes/class-handler.php';
 require_once __DIR__ . '/classes/class-editor.php';
 
 class Blocks_Everywhere {
-	const VERSION = '1.10.0';
+	const VERSION = '1.11.0';
 
 	/**
 	 * Instance variable

--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -54,7 +54,7 @@ class Blocks_Everywhere {
 	 * Constructor
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'load_handlers' ] );
+		add_action( 'plugins_loaded', [ $this, 'load_handlers' ] );
 
 		// Admin editors
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );

--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -54,7 +54,7 @@ class Blocks_Everywhere {
 	 * Constructor
 	 */
 	public function __construct() {
-		add_action( 'plugins_loaded', [ $this, 'load_handlers' ] );
+		add_action( 'init', [ $this, 'load_handlers' ] );
 
 		// Admin editors
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -220,7 +220,6 @@ abstract class Handler {
 					'videopress',
 					'crowdsignal',
 					'screencast',
-					'loom',
 					'imgur',
 				],
 			],

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -8,14 +8,9 @@ class bbPress extends Handler {
 	 * Constructor
 	 */
 	public function __construct() {
-		if ( ! is_admin() ) {
-			add_filter( 'the_editor', [ $this, 'the_editor' ] );
-			add_filter( 'wp_editor_settings', [ $this, 'wp_editor_settings' ], 10, 2 );
-		}
+		add_action( 'bbp_template_redirect', [ $this, 'bbp_template_redirect' ], 11 );
 
-		add_filter( 'bbp_get_the_content', [ $this, 'add_to_bbpress' ] );
-
-		// Ensure blocks are processed when displaying
+		// Ensure blocks are processed when displaying. This needs to run even if the editor isn't loaded
 		add_filter(
 			'bbp_get_forum_content',
 			function( $content ) {
@@ -38,10 +33,44 @@ class bbPress extends Handler {
 			8
 		);
 
+		// Apply block processing to email notifications
 		$default_email = defined( 'BLOCKS_EVERYWHERE_EMAIL' ) ? BLOCKS_EVERYWHERE_EMAIL : false;
 		if ( apply_filters( 'blocks_everywhere_email', $default_email ) ) {
 			add_filter( 'bbp_subscription_mail_message', [ $this, 'remove_blocks_from_email' ], 10, 2 );
 		}
+	}
+
+	public function bbp_template_redirect() {
+		// Decide whether we can load the editor
+		$can_load_editor = apply_filters( 'blocks_everywhere_bbpress_editor', true );
+
+		// If we can't load the editor then first check if we're editing a topic/reply that contains blocks
+		if ( ! $can_load_editor && ! $this->is_editing_blocks() ) {
+			// Nope, just return early so we leave KSES alone - plain text editor
+			return;
+		}
+
+		if ( ! is_admin() ) {
+			// Insert Gutenberg into the page
+			add_filter( 'the_editor', [ $this, 'the_editor' ] );
+
+			// Replace the editor settings
+			add_filter( 'wp_editor_settings', [ $this, 'wp_editor_settings' ], 10, 2 );
+		}
+
+		$this->load_editor( '.bbp-the-content', '.blocks-everywhere' );
+		add_action( 'bbp_head', [ $this, 'bbp_head' ] );
+
+		// If the user doesn't have unfiltered_html then we need to modify KSES to allow blocks
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			$this->setup_kses();
+		}
+
+		// Required to prevent code blocks being reverted from `<code>` to backtics in editor, breaking blocks.
+		// Also helps stop bbp_code_trick_reverse remove a trailing </p>
+		remove_filter( 'bbp_get_form_forum_content', 'bbp_code_trick_reverse' );
+		remove_filter( 'bbp_get_form_topic_content', 'bbp_code_trick_reverse' );
+		remove_filter( 'bbp_get_form_reply_content', 'bbp_code_trick_reverse' );
 
 		// Determine whether to show the bbPress CPT in the backend editor
 		$default_admin = defined( 'BLOCKS_EVERYWHERE_ADMIN' ) ? BLOCKS_EVERYWHERE_ADMIN : false;
@@ -54,19 +83,24 @@ class bbPress extends Handler {
 				add_filter( 'bbp_register_forum_post_type', [ $this, 'support_gutenberg' ] );
 			}
 		}
+	}
 
-		add_action( 'bbp_head', [ $this, 'bbp_head' ] );
+	private function is_editing_blocks() {
+		if ( bbp_is_reply_edit() ) {
+			$reply = bbp_get_reply( bbp_get_reply_id() );
 
-		// Required to prevent code blocks being reverted from `<code>` to backtics in editor, breaking blocks.
-		// Also helps stop bbp_code_trick_reverse remove a trailing </p>
-		remove_filter( 'bbp_get_form_forum_content', 'bbp_code_trick_reverse' );
-		remove_filter( 'bbp_get_form_topic_content', 'bbp_code_trick_reverse' );
-		remove_filter( 'bbp_get_form_reply_content', 'bbp_code_trick_reverse' );
-
-		// If the user doesn't have unfiltered_html then we need to modify KSES to allow blocks
-		if ( ! current_user_can( 'unfiltered_html' ) ) {
-			$this->setup_kses();
+			if ( $reply ) {
+				return has_blocks( $reply->post_content );
+			}
 		}
+
+		if ( bbp_is_topic_edit() ) {
+			$topic = get_post_field( 'post_content', bbp_get_topic_id() );
+
+			return has_blocks( $topic );
+		}
+
+		return false;
 	}
 
 	/**
@@ -154,17 +188,6 @@ class bbPress extends Handler {
 	public function support_gutenberg( $args ) {
 		$args['show_in_rest'] = true;
 		return $args;
-	}
-
-	/**
-	 * Determine whether to load Gutenberg in this forum and then do that.
-	 *
-	 * @param string $content Content.
-	 * @return string Content/
-	 */
-	public function add_to_bbpress( $content ) {
-		$this->load_editor( '.bbp-the-content', '.blocks-everywhere' );
-		return $content;
 	}
 
 	/**

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -40,6 +40,11 @@ class bbPress extends Handler {
 		}
 	}
 
+	/**
+	 * Loads the editor, if needed, after we know what kind of page to display
+	 *
+	 * @return void
+	 */
 	public function bbp_template_redirect() {
 		// Decide whether we can load the editor
 		$can_load_editor = apply_filters( 'blocks_everywhere_bbpress_editor', true );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blocks-everywhere",
-	"version": "1.10.0",
+	"version": "1.11.0",
 	"description": "Gutenberg in WordPress comments, admin pages, bbPress, and BuddyPress.",
 	"main": "src/index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: johnny5, automattic
 Tags: gutenberg, comments, bbpress, buddypress
 Requires at least: 5.8
 Tested up to: 6.1
-Stable tag: 1.10.0
+Stable tag: 1.11.0
 Requires PHP: 5.6
 License: GPLv3
 
@@ -57,6 +57,12 @@ To enable conversion of blocks in email:
 `define( 'BLOCKS_EVERYWHERE_EMAIL', true );`
 
 Or use the filter `blocks_everywhere_email`.
+
+To enable Gutenberg when editing bbPress forums, topics, and replies you can use:
+
+`define( 'BLOCKS_EVERYWHERE_BBPRESS_ADMIN', true );`
+
+Or use `blocks_everywhere_bbpress_admin`
 
 == Theme compatibility ==
 
@@ -117,6 +123,10 @@ The plugin is simple to install:
 2. Gutenberg when editing a comment
 
 == Changelog ==
+
+= 1.11.0 =
+* Allow editor to be enabled/disabled on bbPress forum or user
+* Fix is-pressed style in editor
 
 = 1.10.0 =
 * Process blocks in bbPress notification emails


### PR DESCRIPTION
This changes the bbPress loading code to allow a filter to run for a final decision if the editor should load. This filter can be hooked for a decision based on the forum (`bbp_get_forum_id`), or even the user. That is, particular forums or users can have the editor disabled.

- editor is enabled by default
- editor can be disabled by `blocks_everywhere_bbpress_editor`
- the editor will be forced `true` if the user is editing a topic or reply that contains block content. This stops the user breaking existing content
- block processing always runs, even if the editor is disabled, so the display is always correct
- KSES is left alone if the editor doesn't run

Fixes #55