### PR TITLE
Fix bbPress block processing when running as a plugin

### DIFF
--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -181,7 +181,7 @@ class bbPress extends Handler {
 		}
 
 		// HTML comments have been escaped, we want to re-enable them.
-		$content = preg_replace( '~&lt;!--\w*(.+?):(.+?)\w*--&gt;~i', '<!-- $1:$2 -->', $content );
+		$content = preg_replace( '~&lt;!--\s*(.+?):(.+?)\s*--&gt;~i', '<!-- $1:$2 -->', $content );
 
 		return $content;
 	}

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -9,7 +9,7 @@ class bbPress extends Handler {
 	 */
 	public function __construct() {
 		// Load the editor when the page has been setup, allowing us to decide based on the content
-		add_action( 'bbp_template_redirect', [ $this, 'bbp_template_redirect' ], 11 );
+		add_action( 'bbp_template_redirect', [ $this, 'bbp_template_redirect' ], 8 );
 
 		$default_admin = defined( 'BLOCKS_EVERYWHERE_BBPRESS_ADMIN' ) ? BLOCKS_EVERYWHERE_BBPRESS_ADMIN : false;
 		if ( is_admin() && apply_filters( 'blocks_everywhere_bbpress_admin', $default_admin ) ) {


### PR DESCRIPTION
Fixes #55 (See #65)

This runs the filter setup earlier on the `bbp_template_redirect` hook - bbPress post actions occur at priority 10, which happens before this plugin is hooking in.
See e9b0f20b698098ebb86907f6193ed168061c7e24 where this was introduced.

bbPress hooks `bbp_post_request()` and `bbp_get_request()` functions rather early, where I'd expect them to have run after this filter is processed, or at least much later on the action, but it is what it is.

I'm not sure of why 11 was chosen originally, John do you have any feedback on that?

Additionally, i noticed the regular expression included in e44805a1e6fac5f88370ce1cffcd91e54229e858 was wrong, matching wordy characters, rather than whitespace.