### PR TITLE
Remove upload button

### DIFF
--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -19,7 +19,7 @@ abstract class Handler {
 	 *
 	 * @var array
 	 */
-	private $settings = [];
+	protected $settings = [];
 
 	/**
 	 * Record the do_blocks hook

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -244,7 +244,11 @@ class bbPress extends Handler {
 	public function body_class( $classes ) {
 		$classes[] = 'gutenberg-support';
 
-		$can_upload = isset( $this->settings['editor']['hasUploadPermissions'] ) && $this->settings['editor']['hasUploadPermissions'];
+		$can_upload = false;
+		if ( isset( $this->settings['editor']['hasUploadPermissions'] ) && $this->settings['editor']['hasUploadPermissions'] ) {
+			$can_upload = true;
+		}
+
 		if ( $can_upload ) {
 			$classes[] = 'gutenberg-support-upload';
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,8 @@ The plugin is simple to install:
 * Fix is-pressed style in editor
 * Dont load editor if not logged in
 * Handle no upload permissions better in image block
+* Improve appearance of patterns in block inserter
+* Hide upload button
 
 = 1.10.0 =
 * Process blocks in bbPress notification emails

--- a/src/theme-compat.scss
+++ b/src/theme-compat.scss
@@ -158,6 +158,13 @@
 	}
 }
 
+body:not(.gutenberg-support-upload) {
+	// Hide this button until https://github.com/WordPress/gutenberg/issues/46326 is fixed
+	.block-editor-block-toolbar button[aria-label="Upload external image"] {
+		display: none;
+	}
+}
+
 .gutenberg-support #bbpress-forums fieldset.bbp-form .blocks-everywhere {
 	// Clean up the link popup
 	.block-editor-link-control input[type="text"] {


### PR DESCRIPTION
A bit of a hack that uses CSS to hide the upload button until a core bug can be fixed (details in https://github.com/Automattic/blocks-everywhere/issues/62).

This only works for English language forums.