### PR TITLE
Replace users completer with a topic's users completer

### DIFF
--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -320,6 +320,6 @@ class bbPress extends Handler {
 		}
 
 		// Return an array of user data for each user ID
-		return array_map( [$this, 'get_user_data'], $users );
+		return array_map( [ $this, 'get_user_data' ], $users );
 	}
 }

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -63,6 +63,15 @@ class bbPress extends Handler {
 	}
 
 	/**
+	 * This editor is for bbPress
+	 *
+	 * @return string
+	 */
+	public function get_editor_type() {
+		return 'bbPress';
+	}
+
+	/**
 	 * Loads the editor, if needed, after we know what kind of page to display
 	 *
 	 * @return void

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -47,6 +47,13 @@ class bbPress extends Handler {
 			},
 			8
 		);
+		add_filter(
+			'blocks_everywhere_editor_settings',
+			function( $settings ) {
+				$settings['topicUsers'] = $this->get_topic_users();
+				return $settings;
+			}
+		);
 
 		// Apply block processing to email notifications
 		$default_email = defined( 'BLOCKS_EVERYWHERE_EMAIL' ) ? BLOCKS_EVERYWHERE_EMAIL : false;
@@ -257,5 +264,53 @@ class bbPress extends Handler {
 		}
 
 		return $classes;
+	}
+
+	/**
+	 * Given a $user_id return the data needed for completers
+	 *
+	 * @param $user_id
+	 * @return array
+	 */
+	private function get_user_data( $user_id ) {
+		$user = get_userdata( $user_id );
+		return [
+			'nicename'   => $user->user_nicename,
+			'login'   => $user->user_login,
+			'avatarUrl' => get_avatar_url( $user_id )
+		];
+	}
+
+	/**
+	 * Returns all the users involved in the current topic.
+	 *
+	 * @return array
+	 */
+	public function get_topic_users( $topic_id = 0 ) {
+		$topic_id = bbp_get_topic_id( $topic_id );
+		if ( empty( $topic_id ) ) {
+			return [];
+		}
+
+		$users = [];
+
+		$user_id = bbp_get_topic_author_id();
+		$users[] = $this->get_user_data( $user_id );
+
+		$replies = get_posts( [
+			'post_parent' => $topic_id,
+			'post_type'   => bbp_get_reply_post_type(),
+			'post_status' => bbp_get_public_status_id(),
+		] );
+
+		foreach ( $replies as $reply_id ) {
+			$user_id = bbp_get_reply_author_id( $reply_id );
+			// Add the user ID to the array if it's not already there
+			if ( ! in_array( $user_id, $users ) ) {
+				$users[] = $this->get_user_data( $user_id );
+			}
+		}
+
+		return $users;
 	}
 }

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -301,25 +301,25 @@ class bbPress extends Handler {
 			return [];
 		}
 
-		$users = [];
+		$users = [ bbp_get_topic_author_id( $topic_id ) ];
 
-		$user_id = bbp_get_topic_author_id();
-		$users[] = $this->get_user_data( $user_id );
-
+		// Get an array of replies for the topic
 		$replies = get_posts( [
 			'post_parent' => $topic_id,
 			'post_type'   => bbp_get_reply_post_type(),
 			'post_status' => bbp_get_public_status_id(),
 		] );
 
+		// Loop through the replies and get the user IDs
 		foreach ( $replies as $reply_id ) {
 			$user_id = bbp_get_reply_author_id( $reply_id );
 			// Add the user ID to the array if it's not already there
 			if ( ! in_array( $user_id, $users ) ) {
-				$users[] = $this->get_user_data( $user_id );
+				$users[] = $user_id;
 			}
 		}
 
-		return $users;
+		// Return an array of user data for each user ID
+		return array_map( [$this, 'get_user_data'], $users );
 	}
 }

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -68,7 +68,7 @@ class bbPress extends Handler {
 	 * @return string
 	 */
 	public function get_editor_type() {
-		return 'bbPress';
+		return 'bbpress';
 	}
 
 	/**
@@ -286,7 +286,7 @@ class bbPress extends Handler {
 		return [
 			'nicename'   => $user->user_nicename,
 			'login'   => $user->user_login,
-			'avatarUrl' => get_avatar_url( $user_id )
+			'avatarUrl' => get_avatar_url( $user_id ),
 		];
 	}
 
@@ -304,11 +304,13 @@ class bbPress extends Handler {
 		$users = [ bbp_get_topic_author_id( $topic_id ) ];
 
 		// Get an array of replies for the topic
-		$replies = get_posts( [
-			'post_parent' => $topic_id,
-			'post_type'   => bbp_get_reply_post_type(),
-			'post_status' => bbp_get_public_status_id(),
-		] );
+		$replies = get_posts(
+			[
+				'post_parent' => $topic_id,
+				'post_type'   => bbp_get_reply_post_type(),
+				'post_status' => bbp_get_public_status_id(),
+			]
+		);
 
 		// Loop through the replies and get the user IDs
 		foreach ( $replies as $reply_id ) {

--- a/readme.txt
+++ b/readme.txt
@@ -141,6 +141,7 @@ The plugin is simple to install:
 * Hide upload button
 * Add option to disable auto-embed of URLs, defaulting to off
 * Improve paste handling
+* Include user autocompleter for bbPress, restricted to people in the topic
 
 = 1.10.0 =
 * Process blocks in bbPress notification emails

--- a/src/completer/topic-users.js
+++ b/src/completer/topic-users.js
@@ -4,29 +4,10 @@ export default {
     triggerPrefix: '@',
 
     options: function() {
-        const seen = [];
-        const users = [];
-
-        document.querySelectorAll('.topic > .bbp-topic-author, .topic > .bbp-reply-author').forEach(function (element) {
-            let avatar = element.querySelector('img').src;
-            let name = element.querySelector('.bbp-author-name').innerText;
-            let slugElement = element.querySelector('.bbp-user-nicename');
-            let slug = slugElement ? slugElement.innerText.replace(/[(@)]/g, '') : name;
-
-            if (!seen.includes(slug)) {
-                seen.push(slug);
-                users.push({
-                    avatar: avatar,
-                    name: name,
-                    slug: slug
-                });
-            }
-        });
-
-        return users;
+        return wpBlocksEverywhere.topicUsers || [];
     },
     getOptionKeywords: function( user ) {
-        return [ user.slug ].concat( user.name.split( /\s+/ ) );
+        return [ user.login ].concat( user.nicename.split( /\s+/ ) );
     },
     getOptionLabel: function( user ) {
         return wp.element.concatChildren( [
@@ -34,7 +15,7 @@ export default {
                 'img',
                 {
                     className: 'editor-autocompleters__user-avatar',
-                    src: user.avatar
+                    src: user.avatarUrl
                 }
             ),
             wp.element.createElement(
@@ -42,18 +23,18 @@ export default {
                 {
                     className: 'editor-autocompleters__user-name'
                 },
-                user.name
+                user.nicename
             ),
             wp.element.createElement(
                 'span',
                 {
                     className: 'editor-autocompleters__user-slug'
                 },
-                user.slug
+                user.login
             )
         ] );
     },
     getOptionCompletion: function( user ) {
-        return `@${ user.slug } `;
+        return `@${ user.login } `;
     },
 };

--- a/src/completer/topic-users.js
+++ b/src/completer/topic-users.js
@@ -1,0 +1,59 @@
+export default {
+    name: 'topicUsers',
+    className: 'editor-autocompleters__user',
+    triggerPrefix: '@',
+
+    options: function() {
+        const seen = [];
+        const users = [];
+
+        document.querySelectorAll('.topic > .bbp-topic-author, .topic > .bbp-reply-author').forEach(function (element) {
+            let avatar = element.querySelector('img').src;
+            let name = element.querySelector('.bbp-author-name').innerText;
+            let slugElement = element.querySelector('.bbp-user-nicename');
+            let slug = slugElement ? slugElement.innerText.replace(/[(@)]/g, '') : name;
+
+            if (!seen.includes(slug)) {
+                seen.push(slug);
+                users.push({
+                    avatar: avatar,
+                    name: name,
+                    slug: slug
+                });
+            }
+        });
+
+        return users;
+    },
+    getOptionKeywords: function( user ) {
+        return [ user.slug ].concat( user.name.split( /\s+/ ) );
+    },
+    getOptionLabel: function( user ) {
+        return wp.element.concatChildren( [
+            wp.element.createElement(
+                'img',
+                {
+                    className: 'editor-autocompleters__user-avatar',
+                    src: user.avatar
+                }
+            ),
+            wp.element.createElement(
+                'span',
+                {
+                    className: 'editor-autocompleters__user-name'
+                },
+                user.name
+            ),
+            wp.element.createElement(
+                'span',
+                {
+                    className: 'editor-autocompleters__user-slug'
+                },
+                user.slug
+            )
+        ] );
+    },
+    getOptionCompletion: function( user ) {
+        return `@${ user.slug } `;
+    },
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import { unregisterFormatType } from '@wordpress/rich-text';
 
 import createEditor from './editor';
 import customBlocks from './block-customization';
+import topicUsersCompleter from './completer/topic-users';
 import './styles/style.scss';
 
 const removeNullPostFromFileUploadMiddleware = ( options, next ) => {
@@ -40,6 +41,18 @@ domReady( () => {
 	// Remove some formatting options
 	unregisterFormatType( 'core/text-color' );
 	unregisterFormatType( 'core/image' );
+
+	if ( wpBlocksEverywhere.editorType === 'bbPress' ) {
+		addFilter(
+			'editor.Autocomplete.completers',
+			'blocks-everywhere/autocompleters',
+			( completers = [] ) => {
+				return completers
+					.filter( ( filter ) => filter.name !== 'users' )
+					.concat( [ topicUsersCompleter ] );
+			}
+		);
+	}
 
 	// Add the editor
 	document.querySelectorAll( wpBlocksEverywhere.saveTextarea ).forEach( createEditor );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,7 @@ domReady( () => {
 	unregisterFormatType( 'core/text-color' );
 	unregisterFormatType( 'core/image' );
 
-	if ( wpBlocksEverywhere.editorType === 'bbPress' ) {
+	if ( wpBlocksEverywhere.editorType === 'bbpress' ) {
 		addFilter(
 			'editor.Autocomplete.completers',
 			'blocks-everywhere/autocompleters',

--- a/types.d.ts
+++ b/types.d.ts
@@ -13,6 +13,7 @@ declare var wpBlocksEverywhere: {
 	saveTextarea: any;
 	pluginsUrl: string;
 	allowUrlEmbed: boolean;
+	editorType: string;
 	iso: Iso;
 	container: string;
 };


### PR DESCRIPTION
Suggest just the users interacting in the current topic, works much better in larger installs where there are too many users.

Inspired in @dd32 https://github.com/dd32/wordpress.org/commit/7d3acbb72b22d9de20ec1d8db18f51581d5317fd

~TODO: The list of users should be added somewhere so this doesn't depend on the HTML markup.~