### PR TITLE
Add option to disable auto oembed of URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ To enable Gutenberg when editing bbPress forums, topics, and replies you can use
 
 Or use `blocks_everywhere_bbpress_admin`
 
+### Settings
+
+Some settings are available through the settings object, which is filterable with `blocks_everywhere_editor_settings`.
+
+`allowUrlEmbed` - Enable or disable auto-embed for URLs
+`iso.allowEmbeds` - List of enabled embeds
+`iso.blocks.allowBlocks` - List of enabled blocks
+
 ### Theme compatibility
 
 Gutenberg is placed directly on the page along with your post, forum, etc. This means the contents of the editor will look like the page they will appear on. However, it also means that styles from the page may affect the editor.

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -246,6 +246,7 @@ abstract class Handler {
 			'saveTextarea' => $textarea,
 			'container' => $container,
 			'editorType' => $this->get_editor_type(),
+			'allowUrlEmbed' => true,
 			'pluginsUrl' => plugins_url( '', __DIR__ ),
 			'version' => \Automattic\Blocks_Everywhere\Blocks_Everywhere::VERSION,
 		];

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,14 @@ To enable Gutenberg when editing bbPress forums, topics, and replies you can use
 
 Or use `blocks_everywhere_bbpress_admin`
 
+== Settings ==
+
+Some settings are available through the settings object, which is filterable with `blocks_everywhere_editor_settings`.
+
+`allowUrlEmbed` - Enable or disable auto-embed for URLs
+`iso.allowEmbeds` - List of enabled embeds
+`iso.blocks.allowBlocks` - List of enabled blocks
+
 == Theme compatibility ==
 
 Gutenberg is placed directly on the page along with your post, forum, etc. This means the contents of the editor will look like the page they will appear on. However, it also means that styles from the page may affect the editor.

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,8 @@ The plugin is simple to install:
 * Handle no upload permissions better in image block
 * Improve appearance of patterns in block inserter
 * Hide upload button
+* Add option to disable auto-embed of URLs, defaulting to off
+* Improve paste handling
 
 = 1.10.0 =
 * Process blocks in bbPress notification emails

--- a/src/block-customization/embed.tsx
+++ b/src/block-customization/embed.tsx
@@ -1,6 +1,10 @@
 export default function customizeEmbed( settings ) {
 	return {
 		...settings,
+		transforms: {
+			...settings.transforms,
+			from: wpBlocksEverywhere?.allowUrlEmbed ? settings.transforms.from : [],
+		},
 		variations: settings.variations.filter( ( embed ) => wpBlocksEverywhere?.iso?.allowEmbeds.indexOf( embed.name ) !== -1 ),
 	};
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -12,6 +12,7 @@ declare interface Iso {
 declare var wpBlocksEverywhere: {
 	saveTextarea: any;
 	pluginsUrl: string;
+	allowUrlEmbed: boolean;
 	iso: Iso;
 	container: string;
 };


### PR DESCRIPTION
In the places that this plugin is aimed it's more likely that people want to paste URLs without them being transformed. There's a lot of discussion about improving this in Gutenberg (https://github.com/WordPress/gutenberg/issues/21789) but until it's easier to paste a URL this PR adds the option to disable the feature entirely.