### PR TITLE
Adds a custom paragraph block to change how code is pasted

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Or use `blocks_everywhere_bbpress_admin`
 Some settings are available through the settings object, which is filterable with `blocks_everywhere_editor_settings`.
 
 `allowUrlEmbed` - Enable or disable auto-embed for URLs
+`replaceParagraphCode` - Enable the custom paragraph that converts HTML and PHP code into a code block
+`pastePlainText` - Convert all pasted content to plain text
 `iso.allowEmbeds` - List of enabled embeds
 `iso.blocks.allowBlocks` - List of enabled blocks
 

--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Blocks Everywhere
 Description: Because somewhere is just not enough. Add Gutenberg to WordPress comments, bbPress forums, and BuddyPress streams. Also enables Gutenberg for comment & bbPress moderation.
-Version: 1.11.0
+Version: 1.12.0
 Author: Automattic
 Text Domain: 'blocks-everywhere'
 */
@@ -15,7 +15,7 @@ require_once __DIR__ . '/classes/class-handler.php';
 require_once __DIR__ . '/classes/class-editor.php';
 
 class Blocks_Everywhere {
-	const VERSION = '1.11.0';
+	const VERSION = '1.12.0';
 
 	/**
 	 * Instance variable

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -247,6 +247,7 @@ abstract class Handler {
 			'editorType' => $this->get_editor_type(),
 			'allowUrlEmbed' => false,
 			'pastePlainText' => false,
+			'replaceParagraphCode' => false,
 			'pluginsUrl' => plugins_url( '', __DIR__ ),
 			'version' => \Automattic\Blocks_Everywhere\Blocks_Everywhere::VERSION,
 		];

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -246,6 +246,7 @@ abstract class Handler {
 			'container' => $container,
 			'editorType' => $this->get_editor_type(),
 			'allowUrlEmbed' => false,
+			'pastePlainText' => false,
 			'pluginsUrl' => plugins_url( '', __DIR__ ),
 			'version' => \Automattic\Blocks_Everywhere\Blocks_Everywhere::VERSION,
 		];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blocks-everywhere",
-	"version": "1.11.0",
+	"version": "1.12.0",
 	"description": "Gutenberg in WordPress comments, admin pages, bbPress, and BuddyPress.",
 	"main": "src/index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: johnny5, automattic
 Tags: gutenberg, comments, bbpress, buddypress
 Requires at least: 5.8
 Tested up to: 6.1
-Stable tag: 1.11.0
+Stable tag: 1.12.0
 Requires PHP: 5.6
 License: GPLv3
 
@@ -69,6 +69,8 @@ Or use `blocks_everywhere_bbpress_admin`
 Some settings are available through the settings object, which is filterable with `blocks_everywhere_editor_settings`.
 
 `allowUrlEmbed` - Enable or disable auto-embed for URLs
+`replaceParagraphCode` - Enable the custom paragraph that converts HTML and PHP code into a code block
+`pastePlainText` - Convert all pasted content to plain text
 `iso.allowEmbeds` - List of enabled embeds
 `iso.blocks.allowBlocks` - List of enabled blocks
 
@@ -95,18 +97,20 @@ Content Embed block uses REST API to fetch content to be embedded. This means th
 Blocks Everywhere enables topic REST API on its own, so if the site with bbPress have this plugin installed and configured, its topics can be embedded.
 
 To enable Content Embed block in the editor, pass these settings to `blocks_everywhere_editor_settings` filter:
-```
+
+`
 add_filter( 'blocks_everywhere_editor_settings', function( $settings ) {
 	$settings['iso']['blocks']['allowBlocks'][] = 'blocks-everywhere/support-content';
 	return $settings;
 } );
-```
+`
 
 To enable REST API for forum topics, use next filters:
-```
+
+`
 add_filter( 'blocks_everywhere_admin', '__return_true' );
 add_filter( 'blocks_everywhere_admin_cap', '__return_empty_string' );
-```
+`
 
 REST API is only used when creating content embed and not used to view it. So `blocks_everywhere_admin_cap` can return specific capability to limit users who will have access to API.
 
@@ -131,6 +135,11 @@ The plugin is simple to install:
 2. Gutenberg when editing a comment
 
 == Changelog ==
+
+= 1.12.0 =
+* Add option to auto-detect HTML and PHP code paste
+* Fix pasting of shortcodes
+* Fix inline code on reply page
 
 = 1.11.0 =
 * Allow editor to be enabled/disabled on bbPress forum or user

--- a/src/block-customization/paragraph/edit.tsx
+++ b/src/block-customization/paragraph/edit.tsx
@@ -160,6 +160,7 @@ function ParagraphBlock( { attributes, mergeBlocks, onReplace, onRemove, setAttr
 				data-custom-placeholder={ placeholder ? true : undefined }
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations
+				__unstablePastePlainText={ wpBlocksEverywhere?.pastePlainText ?? false }
 			/>
 		</>
 	);

--- a/src/block-customization/paragraph/edit.tsx
+++ b/src/block-customization/paragraph/edit.tsx
@@ -1,0 +1,168 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _x, isRTL } from '@wordpress/i18n';
+import { ToolbarButton, ToggleControl, __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
+import {
+	AlignmentControl,
+	BlockControls,
+	InspectorControls,
+	RichText,
+	useBlockProps,
+	useSetting,
+} from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { formatLtr } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { useOnEnter } from './use-enter';
+
+const name = 'core/paragraph';
+
+function ParagraphRTLControl( { direction, setDirection } ) {
+	return (
+		isRTL() && (
+			<ToolbarButton
+				icon={ formatLtr }
+				title={ _x( 'Left to right', 'editor button' ) }
+				isActive={ direction === 'ltr' }
+				onClick={ () => {
+					setDirection( direction === 'ltr' ? undefined : 'ltr' );
+				} }
+			/>
+		)
+	);
+}
+
+function hasDropCapDisabled( align ) {
+	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
+}
+
+function isPossiblyCode( blocks ) {
+	if ( blocks.length > 2 ) {
+		return blocks[ 0 ].attributes?.content.startsWith( '&lt;' );
+	}
+
+	return false;
+}
+
+function ParagraphBlock( { attributes, mergeBlocks, onReplace, onRemove, setAttributes, clientId } ) {
+	const { align, content, direction, dropCap, placeholder } = attributes;
+	const isDropCapFeatureEnabled = useSetting( 'typography.dropCap' );
+	const blockProps = useBlockProps( {
+		ref: useOnEnter( { clientId, content } ),
+		className: classnames( {
+			'has-drop-cap': hasDropCapDisabled( align ) ? false : dropCap,
+			[ `has-text-align-${ align }` ]: align,
+		} ),
+		style: { direction },
+	} );
+
+	let helpText;
+	if ( hasDropCapDisabled( align ) ) {
+		helpText = __( 'Not available for aligned text.' );
+	} else if ( dropCap ) {
+		helpText = __( 'Showing large initial letter.' );
+	} else {
+		helpText = __( 'Toggle to show a large initial letter.' );
+	}
+
+	function hijackedReplace( values ) {
+		if ( isPossiblyCode( values ) ) {
+			const content = values.map( ( block ) => block.attributes.content ).join( '\n' );
+			const block = createBlock( 'core/code', { content } );
+
+			onReplace( [ block ] );
+			return;
+		}
+
+		return onReplace( values );
+	}
+
+	return (
+		<>
+			<BlockControls group="block">
+				<AlignmentControl
+					value={ align }
+					onChange={ ( newAlign ) =>
+						setAttributes( {
+							align: newAlign,
+							dropCap: hasDropCapDisabled( newAlign ) ? false : dropCap,
+						} )
+					}
+				/>
+				<ParagraphRTLControl
+					direction={ direction }
+					setDirection={ ( newDirection ) => setAttributes( { direction: newDirection } ) }
+				/>
+			</BlockControls>
+			{ isDropCapFeatureEnabled && (
+				<InspectorControls __experimentalGroup="typography">
+					<ToolsPanelItem
+						hasValue={ () => !! dropCap }
+						label={ __( 'Drop cap' ) }
+						onDeselect={ () => setAttributes( { dropCap: undefined } ) }
+						resetAllFilter={ () => ( { dropCap: undefined } ) }
+						panelId={ clientId }
+					>
+						<ToggleControl
+							label={ __( 'Drop cap' ) }
+							checked={ !! dropCap }
+							onChange={ () => setAttributes( { dropCap: ! dropCap } ) }
+							help={ helpText }
+							disabled={ hasDropCapDisabled( align ) ? true : false }
+						/>
+					</ToolsPanelItem>
+				</InspectorControls>
+			) }
+
+			<RichText
+				identifier="content"
+				tagName="p"
+				{ ...blockProps }
+				value={ content }
+				onChange={ ( newContent ) => setAttributes( { content: newContent } ) }
+				onSplit={ ( value, isOriginal ) => {
+					let newAttributes;
+
+					if ( isOriginal || value ) {
+						newAttributes = {
+							...attributes,
+							content: value,
+						};
+					}
+
+					const block = createBlock( name, newAttributes );
+
+					if ( isOriginal ) {
+						block.clientId = clientId;
+					}
+
+					return block;
+				} }
+				onMerge={ mergeBlocks }
+				onReplace={ hijackedReplace }
+				onRemove={ onRemove }
+				aria-label={
+					content
+						? __( 'Paragraph block' )
+						: __( 'Empty block; start writing or type forward slash to choose a block' )
+				}
+				data-empty={ content ? false : true }
+				placeholder={ placeholder || __( 'Type / to choose a block' ) }
+				data-custom-placeholder={ placeholder ? true : undefined }
+				__unstableEmbedURLOnPaste
+				__unstableAllowPrefixTransformations
+			/>
+		</>
+	);
+}
+
+export default ParagraphBlock;

--- a/src/block-customization/paragraph/index.tsx
+++ b/src/block-customization/paragraph/index.tsx
@@ -4,6 +4,12 @@
 
 import { createBlock } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+
+import edit from './edit';
+
 export default function customizeParagraph( settings ) {
 	const hasHeading = wpBlocksEverywhere.iso.blocks.allowBlocks.indexOf( 'core/heading' ) !== -1;
 	const boldNodes = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'h7' ];
@@ -15,6 +21,7 @@ export default function customizeParagraph( settings ) {
 
 	return {
 		...settings,
+		edit,
 		transforms: {
 			...settings.transforms,
 			from: [

--- a/src/block-customization/paragraph/index.tsx
+++ b/src/block-customization/paragraph/index.tsx
@@ -12,6 +12,7 @@ import edit from './edit';
 
 export default function customizeParagraph( settings ) {
 	const hasHeading = wpBlocksEverywhere.iso.blocks.allowBlocks.indexOf( 'core/heading' ) !== -1;
+	const replaceParagraph = wpBlocksEverywhere?.replaceParagraphCode ?? false;
 	const boldNodes = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'h7' ];
 	const plainNodes = [ 'table' ];
 
@@ -21,7 +22,7 @@ export default function customizeParagraph( settings ) {
 
 	return {
 		...settings,
-		edit,
+		edit: replaceParagraph ? edit : settings.edit,
 		transforms: {
 			...settings.transforms,
 			from: [

--- a/src/block-customization/paragraph/use-enter.tsx
+++ b/src/block-customization/paragraph/use-enter.tsx
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { ENTER } from '@wordpress/keycodes';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { hasBlockSupport, createBlock } from '@wordpress/blocks';
+
+export function useOnEnter( props ) {
+	const { batch } = useRegistry();
+	const { moveBlocksToPosition, replaceInnerBlocks, duplicateBlocks, insertBlock } = useDispatch( blockEditorStore );
+	const { getBlockRootClientId, getBlockIndex, getBlockOrder, getBlockName, getBlock, getNextBlockClientId } =
+		useSelect( blockEditorStore );
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			if ( event.keyCode !== ENTER ) {
+				return;
+			}
+
+			const { content, clientId } = propsRef.current;
+
+			// The paragraph should be empty.
+			if ( content.length ) {
+				return;
+			}
+
+			const wrapperClientId = getBlockRootClientId( clientId );
+
+			if ( ! hasBlockSupport( getBlockName( wrapperClientId ), '__experimentalOnEnter', false ) ) {
+				return;
+			}
+
+			const order = getBlockOrder( wrapperClientId );
+
+			event.preventDefault();
+
+			const position = order.indexOf( clientId );
+
+			// If it is the last block, exit.
+			if ( position === order.length - 1 ) {
+				moveBlocksToPosition(
+					[ clientId ],
+					wrapperClientId,
+					getBlockRootClientId( wrapperClientId ),
+					getBlockIndex( wrapperClientId ) + 1
+				);
+				return;
+			}
+
+			// If it is in the middle, split the block in two.
+			const wrapperBlock = getBlock( wrapperClientId );
+			batch( () => {
+				duplicateBlocks( [ wrapperClientId ] );
+				const blockIndex = getBlockIndex( wrapperClientId );
+
+				replaceInnerBlocks( wrapperClientId, wrapperBlock.innerBlocks.slice( 0, position ) );
+				replaceInnerBlocks(
+					getNextBlockClientId( wrapperClientId ),
+					wrapperBlock.innerBlocks.slice( position + 1 )
+				);
+				insertBlock(
+					createBlock( 'core/paragraph' ),
+					blockIndex + 1,
+					getBlockRootClientId( wrapperClientId ),
+					true
+				);
+			} );
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,4 +17,5 @@ declare var wpBlocksEverywhere: {
 	iso: Iso;
 	container: string;
 	pastePlainText: boolean;
+	replaceParagraphCode: boolean;
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,4 +16,5 @@ declare var wpBlocksEverywhere: {
 	editorType: string;
 	iso: Iso;
 	container: string;
+	pastePlainText: boolean;
 };


### PR DESCRIPTION
As discussed in #60 this is a way to tune the Gutenberg copy/paste to be more suited for forums.

It swaps the core paragraph for a custom one that overrides the `onReplace` function to check the incoming blocks. If there are multiple blocks and the content of the first one starts with < then the blocks are considered 'code', and merged together into a code block.