### PR TITLE
Use nicename instead of login for autocompleter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ The plugin is simple to install:
 * Add option to auto-detect HTML and PHP code paste
 * Fix pasting of shortcodes
 * Fix inline code on reply page
+* Improve name shown in bbPress autocompleter
 
 = 1.11.0 =
 * Allow editor to be enabled/disabled on bbPress forum or user

--- a/src/completer/topic-users.js
+++ b/src/completer/topic-users.js
@@ -7,7 +7,7 @@ export default {
         return wpBlocksEverywhere.topicUsers || [];
     },
     getOptionKeywords: function( user ) {
-        return [ user.login ].concat( user.nicename.split( /\s+/ ) );
+        return user.nicename.split( /\s+/ );
     },
     getOptionLabel: function( user ) {
         return wp.element.concatChildren( [
@@ -25,16 +25,9 @@ export default {
                 },
                 user.nicename
             ),
-            wp.element.createElement(
-                'span',
-                {
-                    className: 'editor-autocompleters__user-slug'
-                },
-                user.login
-            )
         ] );
     },
     getOptionCompletion: function( user ) {
-        return `@${ user.login } `;
+        return `@${ user.nicename } `;
     },
 };


### PR DESCRIPTION
* `nicename` is used everywhere and not login in bbPress.
* Use bbPress methods to retrieve user information.