### PR TITLE
Handle self-closing block markup

### DIFF
--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -199,8 +199,12 @@ class bbPress extends Handler {
 			return $content;
 		}
 
-		// HTML comments have been escaped, we want to re-enable them.
-		$content = preg_replace( '~&lt;!--\s*(.+?):(.+?)\s*--&gt;~i', '<!-- $1:$2 -->', $content );
+		// HTML comments have been escaped, we want to re-enable them. We need to handle:
+		//   <!-- namesapce:name {"somejson"} -->
+		//   <!-- namespace:name {"somejson"} /-->
+		//   <!-- namespace:name -->
+		//   <!-- namespace:name /-->
+		$content = preg_replace( '~&lt;!--\s*(.+?):(.+?)\s*(\{.*?\}\s*)?\s*(/)*--&gt;~', '<!-- $1:$2 $3$4-->', $content );
 
 		return $content;
 	}

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -200,11 +200,22 @@ class bbPress extends Handler {
 		}
 
 		// HTML comments have been escaped, we want to re-enable them. We need to handle:
-		//   <!-- namesapce:name {"somejson"} -->
-		//   <!-- namespace:name {"somejson"} /-->
-		//   <!-- namespace:name -->
-		//   <!-- namespace:name /-->
-		$content = preg_replace( '~&lt;!--\s*(.+?):(.+?)\s*(\{.*?\}\s*)?\s*(/)*--&gt;~', '<!-- $1:$2 $3$4-->', $content );
+		//   <!-- wp:namespace/name {"somejson"} -->
+		//   <!-- wp:namespace/name {"somejson"} /-->
+		//   <!-- wp:namespace/name -->
+		//   <!-- wp:namespace/name /-->
+		$block_syntax = 'wp:[a-z0-9-/]+';
+		$content = preg_replace(
+			'@&lt;!--(' .
+				// Opening blocks, supporting a self-closing block
+				"(?:\s*{$block_syntax}\s*(?:\{.*?\}\s*)?[/]?)" .
+				'|' .
+				// Closing block
+				"(?:\s*[/]{$block_syntax}\s*)" .
+			')--&gt;@',
+			'<!--$1-->',
+			$content
+		);
 
 		return $content;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -145,6 +145,11 @@ The plugin is simple to install:
 
 == Changelog ==
 
+= 1.13.0 =
+* Improve the `replaceParagraphCode` function to better detect code
+* Improve bbPress KSES handling
+* Fix error when drag/dropping or pasting an image and upload has been disabled
+
 = 1.12.0 =
 * Add option to auto-detect HTML and PHP code paste
 * Fix pasting of shortcodes


### PR DESCRIPTION
We need to handle self-closing block markup.

`<!-- wp:thing /-->`

The `/-->` is important. The current regex is converting it to `/ -->`, which breaks the block.

The regex has also been changed to look for attributes, in case the attributes contain the closing tag markup.

I'll put together some proper unit tests for this, but for now: https://regex101.com/r/I5dyRv/1