### PR TITLE
Fix image paste / drag drop when no upload capabilities

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -7,6 +7,7 @@ import { mediaUpload } from '@wordpress/editor';
 import { render } from '@wordpress/element';
 import IsolatedBlockEditor, { EditorLoaded } from '@automattic/isolated-block-editor';
 import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Local dependencies
@@ -51,6 +52,10 @@ function createEditorContainer( container, textarea, settings ) {
 		// Connect the media uploader if it's enabled
 		settings.editor.mediaUpload = mediaUpload;
 		addFilter( 'editor.MediaUpload', 'blocks-everywhere/media-upload', () => MediaUpload );
+	} else {
+		settings.editor.mediaUpload = ( { onError } ) => {
+			onError( __( 'File uploading is disabled. Please use an image block and an external image URL.', 'blocks-everywhere' ) );
+		};
 	}
 
 	render(

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -54,9 +54,16 @@
 }
 
 /* Fix some Gutenberg issues when media upload is disabled */
-body:not(.gutenberg-support-upload) .block-editor-media-flow__url-input {
-	margin-top: 0;
-	border-top: none;
+body:not(.gutenberg-support-upload) {
+	.block-editor-media-flow__url-input {
+		margin-top: 0;
+		border-top: none;
+	}
+
+	// Hide upload button
+	.block-editor-media-replace-flow__media-upload-menu {
+		display: none;
+	}
 }
 
 // Make the change from loading to loaded a bit better


### PR DESCRIPTION
If upload is disabled then we still need to handle pasting images or drag/drop image events.

This sets the `mediaUpload` and just calls the `onError` with a message saying that image uploading is disabled. The event gets converted into an empty image block.