### PR TITLE
Add/search in content embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 	"dependencies": {
 		"@automattic/color-studio": "^2.5.0",
 		"@automattic/isolated-block-editor": "2.21.0",
-		"@automattic/typography": "^1.0.0"
+		"@automattic/typography": "^1.0.0",
+		"use-debounce": "^9.0.2"
 	},
 	"release-it": {
 		"github": {

--- a/src/support-content-block/edit.scss
+++ b/src/support-content-block/edit.scss
@@ -9,6 +9,10 @@
   .components-notice-list .components-notice__content {
     margin: 4px 25px 4px 0;
   }
+
+  &__search-slot {
+    flex-basis: 100%;
+  }
 }
 
 .be-support-content-confirm-anchor {

--- a/src/support-content-block/edit.scss
+++ b/src/support-content-block/edit.scss
@@ -63,11 +63,16 @@
 
   z-index: 10000;
 
+  &__loading {
+    display: flex;
+  }
+
   &__list {
   }
 
   &__item {
     padding: 10px 20px;
+    cursor: pointer;
 
     &:hover {
         background-color: $studio-gray-0;

--- a/src/support-content-block/edit.scss
+++ b/src/support-content-block/edit.scss
@@ -80,6 +80,11 @@
     font-weight: 500;
     font-size: $font-body;
     line-height: 24px;
+
+    overflow: hidden;
+    display: block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &__link {
@@ -88,5 +93,10 @@
     font-weight: 400;
     font-size: $font-body-small;
     line-height: 20px;
+
+    overflow: hidden;
+    display: block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/src/support-content-block/edit.scss
+++ b/src/support-content-block/edit.scss
@@ -12,6 +12,7 @@
 
   &__search-slot {
     flex-basis: 100%;
+    position: relative;
   }
 }
 
@@ -44,5 +45,48 @@
         box-shadow: inset 0 0 0 1px $studio-red-50 !important;
       }
     }
+  }
+}
+
+.be-support-content-search-results {
+  padding: 10px;
+  background-color: $studio-white;
+
+  border: 1px solid #D8DBDD;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+
+  position: absolute;
+  left: 0;
+  top: 12px;
+  width: 100%;
+
+  z-index: 10000;
+
+  &__list {
+  }
+
+  &__item {
+    padding: 20px 10px;
+
+    &:hover {
+        background-color: $studio-gray-0;
+    }
+  }
+
+  &__title {
+    font-family: "SF Pro Text", $sans;
+    font-style: normal;
+    font-weight: 500;
+    font-size: $font-body;
+    line-height: 24px;
+  }
+
+  &__link {
+    font-family: "SF Pro Text", $sans;
+    font-style: normal;
+    font-weight: 400;
+    font-size: $font-body-small;
+    line-height: 20px;
   }
 }

--- a/src/support-content-block/edit.scss
+++ b/src/support-content-block/edit.scss
@@ -67,7 +67,7 @@
   }
 
   &__item {
-    padding: 20px 10px;
+    padding: 10px 20px;
 
     &:hover {
         background-color: $studio-gray-0;

--- a/src/support-content-block/edit.tsx
+++ b/src/support-content-block/edit.tsx
@@ -26,7 +26,7 @@ export const Edit = compose( withNotices )( ( props: EditProps ) => {
 
 	const instructions = __( 'Embed a Support doc or a forum topic.', 'blocks-everywhere' );
 	const mismatchErrorMessage = __( 'It does not look like a Support doc or a forum topic URL.', 'blocks-everywhere' );
-	const placeholder = __( 'Enter URL to embed here…', 'blocks-everywhere' );
+	const placeholder = __( 'Search or insert URL', 'blocks-everywhere' );
 
 	const [ isConfirmed, setIsConfirmed ] = useState( props.attributes.isConfirmed );
 	const [ isEditing, setIsEditing ] = useState( false );

--- a/src/support-content-block/embed-placeholder.tsx
+++ b/src/support-content-block/embed-placeholder.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, Placeholder } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import classnames from 'classnames';
 import './edit.scss';
+import { useState } from '@wordpress/element';
+import { debounce } from '@wordpress/compose';
+import { SearchResults } from './search-results';
 
 type EmbedPlaceHolderProps = {
 	icon: JSX.Element;
@@ -20,6 +23,13 @@ type EmbedPlaceHolderProps = {
  * UI for configuring the embed
  */
 export const EmbedPlaceHolder = ( props: EmbedPlaceHolderProps ) => {
+	const [ search, setSearch ] = useState( null );
+
+	const updateSearch = useCallback(
+		debounce( ( search ) => setSearch( search ), 1000 ),
+		[]
+	);
+
 	return (
 		<div className={ classnames( 'be-support-content-placeholder', props.className ) }>
 			<Placeholder
@@ -39,13 +49,19 @@ export const EmbedPlaceHolder = ( props: EmbedPlaceHolderProps ) => {
 						value={ props.url }
 						className="components-placeholder__input"
 						placeholder={ props.placeholder }
-						onChange={ ( event ) => props.updateUrl( event.target.value ) }
+						onChange={ ( event ) => {
+							props.updateUrl( event.target.value );
+							updateSearch( event.target.value );
+						} }
 					/>
 					<Button isPrimary type="submit">
 						{ _x( 'Embed', 'button label', 'blocks-everywhere' ) }
 					</Button>
 				</form>
 			</Placeholder>
+			<div>
+				<SearchResults search={ search } />
+			</div>
 		</div>
 	);
 };

--- a/src/support-content-block/embed-placeholder.tsx
+++ b/src/support-content-block/embed-placeholder.tsx
@@ -58,10 +58,10 @@ export const EmbedPlaceHolder = ( props: EmbedPlaceHolderProps ) => {
 						{ _x( 'Embed', 'button label', 'blocks-everywhere' ) }
 					</Button>
 				</form>
+				<div className="be-support-content-placeholder__search-slot">
+					<SearchResults search={ search } />
+				</div>
 			</Placeholder>
-			<div>
-				<SearchResults search={ search } />
-			</div>
 		</div>
 	);
 };

--- a/src/support-content-block/embed-placeholder.tsx
+++ b/src/support-content-block/embed-placeholder.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback } from 'react';
+import React from 'react';
+import { useEffect } from '@wordpress/element';
 import { Button, Placeholder } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import classnames from 'classnames';
 import './edit.scss';
 import { useState } from '@wordpress/element';
-import { debounce } from '@wordpress/compose';
 import { SearchResults } from './search-results';
 
 type EmbedPlaceHolderProps = {
@@ -24,11 +24,16 @@ type EmbedPlaceHolderProps = {
  */
 export const EmbedPlaceHolder = ( props: EmbedPlaceHolderProps ) => {
 	const [ search, setSearch ] = useState( null );
+	const isUrl = props.url?.startsWith( 'http://' ) || props.url?.startsWith( 'https://' );
+	const isSearchable = ! isUrl && props.url?.length > 3;
 
-	const updateSearch = useCallback(
-		debounce( ( search ) => setSearch( search ), 1000 ),
-		[]
-	);
+	useEffect( () => {
+		if ( isSearchable ) {
+			setSearch( props.url );
+		} else {
+			setSearch( null );
+		}
+	}, [ props.url, isSearchable ] );
 
 	return (
 		<div className={ classnames( 'be-support-content-placeholder', props.className ) }>
@@ -49,24 +54,23 @@ export const EmbedPlaceHolder = ( props: EmbedPlaceHolderProps ) => {
 						value={ props.url }
 						className="components-placeholder__input"
 						placeholder={ props.placeholder }
-						onChange={ ( event ) => {
-							props.updateUrl( event.target.value );
-							updateSearch( event.target.value );
-						} }
+						onChange={ ( event ) => props.updateUrl( event.target.value ) }
 					/>
-					<Button isPrimary type="submit">
+					<Button isPrimary type="submit" disabled={ ! isUrl } aria-disabled={ ! isUrl }>
 						{ _x( 'Embed', 'button label', 'blocks-everywhere' ) }
 					</Button>
 				</form>
-				<div className="be-support-content-placeholder__search-slot">
-					<SearchResults
-						search={ search }
-						setUrl={ ( url ) => {
-							props.updateUrl( url );
-							setSearch( url );
-						} }
-					/>
-				</div>
+				{ isSearchable && (
+					<div className="be-support-content-placeholder__search-slot">
+						<SearchResults
+							search={ search }
+							setUrl={ ( url ) => {
+								props.updateUrl( url );
+								setSearch( url );
+							} }
+						/>
+					</div>
+				) }
 			</Placeholder>
 		</div>
 	);

--- a/src/support-content-block/embed-placeholder.tsx
+++ b/src/support-content-block/embed-placeholder.tsx
@@ -59,7 +59,13 @@ export const EmbedPlaceHolder = ( props: EmbedPlaceHolderProps ) => {
 					</Button>
 				</form>
 				<div className="be-support-content-placeholder__search-slot">
-					<SearchResults search={ search } />
+					<SearchResults
+						search={ search }
+						setUrl={ ( url ) => {
+							props.updateUrl( url );
+							setSearch( url );
+						} }
+					/>
 				</div>
 			</Placeholder>
 		</div>

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -23,6 +23,8 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 		if (!props.search || props.search.length <= 3 || props.search.startsWith('https://') || props.search.startsWith('http://')) {
 			setResults([]);
 		} else {
+			setResults([]);
+
 			getSearchResults(props.search).then((newResults) => {
 				if (!cancelled) {
 					setResults(newResults);
@@ -54,10 +56,27 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 	);
 };
 
+const MAX_RESULTS = 5;
+
 async function getSearchResults( search: string ): Promise< SearchResult[] > {
-	// https://public-api.wordpress.com/wp/v2/sites/9619154/pages?search=change%20domain
-	return [
-		{ title: 'Domains » Change a Domain Name', url: 'https://wordpress.com/support/domains/change-a-domain/' },
-		{ title: 'How do I change a Domain Name', url: 'https://wordpress.com/forums/topic/change-domain-name-266/' },
-	];
+	const apiUrl = `https://public-api.wordpress.com/wp/v2/sites/en.support.wordpress.com/pages?search=${ encodeURIComponent( search ) }`;
+
+	const response = await fetch( apiUrl );
+
+	if ( ! response.ok ) {
+		return [];
+	}
+
+	const pages = await response.json();
+
+	const results = pages.map( ( page ) => ( {
+		title: page.title.rendered.replace("&nbsp;", " "),
+		url: page.link,
+	}));
+
+	if ( results.length > MAX_RESULTS ) {
+		return results.slice( 0, MAX_RESULTS );
+	}
+
+	return results
 }

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -40,7 +40,7 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 		return null;
 	}
 
-	if ( ! results ) {
+	if ( ! results.length ) {
 		return;
 	}
 

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
-import React from 'react';
 import { __ } from '@wordpress/i18n';
+import { useDebounce } from 'use-debounce';
 
 type SearchResultsProps = {
 	search: string;
@@ -22,34 +22,26 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 
 	const [ loading, setLoading ] = useState( false );
 
+	const [ debouncedSearch ] = useDebounce( props.search, 1000 );
+
 	useEffect( () => {
-		let cancelled = false;
-
 		setResults( [] );
-
-		if (
-			props.search &&
-			props.search.length > 3 &&
-			! props.search.startsWith( 'https://' ) &&
-			! props.search.startsWith( 'http://' )
-		) {
-			setLoading( true );
-
-			getSearchResults( props.search ).then( ( newResults ) => {
-				if ( ! cancelled ) {
-					setResults( newResults );
-				}
-
-				setLoading( false );
-			} );
-		}
-		return () => {
-			cancelled = true;
-		};
+		setLoading( true );
 	}, [ props.search ] );
+
+	useEffect( () => {
+		getSearchResults( debouncedSearch ).then( ( newResults ) => {
+			setResults( newResults );
+			setLoading( false );
+		} );
+	}, [ debouncedSearch ] );
 
 	if ( ! loading && results.length === 0 ) {
 		return null;
+	}
+
+	if ( ! results ) {
+		return;
 	}
 
 	return (

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -39,7 +39,7 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 	}
 
 	return (
-		<Popover variant="unstyled" offset={ -16 } placement="bottom-start">
+		<Popover variant="unstyled" offset={ 16 } placement="bottom-start">
 			<div>
 				<Elevation value={ 3 } />
 

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -39,17 +39,17 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 	}
 
 	return (
-		<Popover variant="unstyled" offset={ 16 } placement="bottom-start">
-			<div>
-				<Elevation value={ 3 } />
-
+		<div className="be-support-content-search-results">
+			<div className="be-support-content-search-results__list">
 				{ results.map( ( result ) => (
-					<div>
-						<div>{ result.title }</div>
-						<a href={ result.url } target="_blank"></a>
+					<div className="be-support-content-search-results__item">
+						<div className="be-support-content-search-results__title">{ result.title }</div>
+						<a className="be-support-content-search-results__link" href={ result.url } target="_blank">
+							{ result.url }
+						</a>
 					</div>
 				) ) }
 			</div>
-		</Popover>
+		</div>
 	);
 };

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+import { __experimentalElevation as Elevation, MenuItem, NavigableMenu, Popover } from '@wordpress/components';
+
+type SearchResultsProps = {
+	search: string;
+};
+
+type SearchResult = {
+	title: string;
+	url: string;
+};
+
+/**
+ * Search for matching content and display search results
+ * props.search is the search string, should be debounced.
+ */
+export const SearchResults = ( props: SearchResultsProps ) => {
+	const [ results, setResults ] = useState< SearchResult[] >( [
+		{ title: 'Domains » Change a Domain Name', url: 'https://wordpress.com/support/domains/change-a-domain/' },
+		{ title: 'How do I change a Domain Name', url: 'https://wordpress.com/forums/topic/change-domain-name-266/' },
+	] );
+
+	useEffect( () => {
+		// start fetching
+	}, [ props.search ] );
+
+	if ( ! props.search || props.search.length < 3 ) {
+		return null;
+	}
+
+	if ( props.search.startsWith( 'https://' ) || props.search.startsWith( 'http://' ) ) {
+		return null;
+	}
+
+	if ( results.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Popover variant="unstyled" offset={ -16 } placement="bottom-start">
+			<div>
+				<Elevation value={ 3 } />
+
+				{ results.map( ( result ) => (
+					<div>
+						<div>{ result.title }</div>
+						<a href={ result.url } target="_blank"></a>
+					</div>
+				) ) }
+			</div>
+		</Popover>
+	);
+};

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import {useEffect, useState} from '@wordpress/element';
 import React from 'react';
-import { __experimentalElevation as Elevation, MenuItem, NavigableMenu, Popover } from '@wordpress/components';
 
 type SearchResultsProps = {
 	search: string;
@@ -17,22 +15,24 @@ type SearchResult = {
  * props.search is the search string, should be debounced.
  */
 export const SearchResults = ( props: SearchResultsProps ) => {
-	const [ results, setResults ] = useState< SearchResult[] >( [
-		{ title: 'Domains » Change a Domain Name', url: 'https://wordpress.com/support/domains/change-a-domain/' },
-		{ title: 'How do I change a Domain Name', url: 'https://wordpress.com/forums/topic/change-domain-name-266/' },
-	] );
+	const [ results, setResults ] = useState< SearchResult[] >( [] );
 
 	useEffect( () => {
-		// start fetching
+		let cancelled = false;
+
+		if (!props.search || props.search.length <= 3 || props.search.startsWith('https://') || props.search.startsWith('http://')) {
+			setResults([]);
+		} else {
+			getSearchResults(props.search).then((newResults) => {
+				if (!cancelled) {
+					setResults(newResults);
+				}
+			});
+		}
+		return () => {
+			cancelled = true;
+		}
 	}, [ props.search ] );
-
-	if ( ! props.search || props.search.length < 3 ) {
-		return null;
-	}
-
-	if ( props.search.startsWith( 'https://' ) || props.search.startsWith( 'http://' ) ) {
-		return null;
-	}
 
 	if ( results.length === 0 ) {
 		return null;
@@ -53,3 +53,11 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 		</div>
 	);
 };
+
+async function getSearchResults( search: string ): Promise< SearchResult[] > {
+	// https://public-api.wordpress.com/wp/v2/sites/9619154/pages?search=change%20domain
+	return [
+		{ title: 'Domains » Change a Domain Name', url: 'https://wordpress.com/support/domains/change-a-domain/' },
+		{ title: 'How do I change a Domain Name', url: 'https://wordpress.com/forums/topic/change-domain-name-266/' },
+	];
+}

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -40,10 +40,6 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 		return null;
 	}
 
-	if ( ! results.length ) {
-		return;
-	}
-
 	return (
 		<div className="be-support-content-search-results">
 			<div className="be-support-content-search-results__list">

--- a/src/support-content-block/search-results.tsx
+++ b/src/support-content-block/search-results.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import React from 'react';
 
 type SearchResultsProps = {
@@ -17,23 +17,30 @@ type SearchResult = {
 export const SearchResults = ( props: SearchResultsProps ) => {
 	const [ results, setResults ] = useState< SearchResult[] >( [] );
 
+	const [ loading, setLoading ] = useState( false );
+
 	useEffect( () => {
 		let cancelled = false;
 
-		if (!props.search || props.search.length <= 3 || props.search.startsWith('https://') || props.search.startsWith('http://')) {
-			setResults([]);
+		if (
+			! props.search ||
+			props.search.length <= 3 ||
+			props.search.startsWith( 'https://' ) ||
+			props.search.startsWith( 'http://' )
+		) {
+			setResults( [] );
 		} else {
-			setResults([]);
+			setResults( [] );
 
-			getSearchResults(props.search).then((newResults) => {
-				if (!cancelled) {
-					setResults(newResults);
+			getSearchResults( props.search ).then( ( newResults ) => {
+				if ( ! cancelled ) {
+					setResults( newResults );
 				}
-			});
+			} );
 		}
 		return () => {
 			cancelled = true;
-		}
+		};
 	}, [ props.search ] );
 
 	if ( results.length === 0 ) {
@@ -59,7 +66,9 @@ export const SearchResults = ( props: SearchResultsProps ) => {
 const MAX_RESULTS = 5;
 
 async function getSearchResults( search: string ): Promise< SearchResult[] > {
-	const apiUrl = `https://public-api.wordpress.com/wp/v2/sites/en.support.wordpress.com/pages?search=${ encodeURIComponent( search ) }`;
+	const apiUrl = `https://public-api.wordpress.com/wp/v2/sites/en.support.wordpress.com/pages?search=${ encodeURIComponent(
+		search
+	) }`;
 
 	const response = await fetch( apiUrl );
 
@@ -70,13 +79,13 @@ async function getSearchResults( search: string ): Promise< SearchResult[] > {
 	const pages = await response.json();
 
 	const results = pages.map( ( page ) => ( {
-		title: page.title.rendered.replace("&nbsp;", " "),
+		title: page.title.rendered.replace( '&nbsp;', ' ' ),
 		url: page.link,
-	}));
+	} ) );
 
 	if ( results.length > MAX_RESULTS ) {
 		return results.slice( 0, MAX_RESULTS );
 	}
 
-	return results
+	return results;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13801,6 +13801,11 @@ url-loader@^4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
+use-debounce@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-9.0.2.tgz#2883982ec1eb79affec46f14047244057b78161c"
+  integrity sha512-QLyB0sxt9F5AisGDrUybCRJSLE60bTQR0yXc+IebNGUu1GCXwii1zsZl82mPGdWqDVQy7+1FKMLHQUixxf5Nbw==
+
 use-lilius@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/use-lilius/-/use-lilius-2.0.3.tgz#07cdf1dea72da6f0c72d9234c16516fbbd396e2d"


### PR DESCRIPTION
Adds the ability to search for WP.com support pages directly from the Content Embed block.

## Testing instructions

- Deploy this PR to sandbox
- In the editor, create a new Content Block by pressing `/`
- In the input field, enter some keywords, for example, 'Change Domain'
- Verify you are presented with the list of the relevant support pages
- Click on the support page item to insert its URL. 