### PR TITLE
Make is_editing_blocks() truthful during reply/topic edit submissions

### DIFF
--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -145,16 +145,32 @@ class bbPress extends Handler {
 	 * @return boolean
 	 */
 	private function is_editing_blocks() {
-		if ( bbp_is_reply_edit() ) {
-			$reply = bbp_get_reply( bbp_get_reply_id() );
+		$topic_id = 0;
+		$reply_id = 0;
+
+		if ( bbp_is_post_request() && ! empty( $_POST['action'] ) ) {
+			$action = $_POST['action'];
+			if ( 'bbp-edit-reply' === $action ) {
+				$reply_id = $_POST['bbp_reply_id'];
+			} elseif ( 'bbp-edit-topic' === $action ) {
+				$topic_id = $_POST['bbp_topic_id'];
+			}
+		} elseif ( bbp_is_reply_edit() ) {
+			$reply_id = bbp_get_reply_id();
+		} elseif ( bbp_is_topic_edit() ) {
+			$topic_id = bbp_get_topic_id();
+		}
+
+		if ( $reply_id ) {
+			$reply = bbp_get_reply( $reply_id );
 
 			if ( $reply ) {
 				return has_blocks( $reply->post_content );
 			}
 		}
 
-		if ( bbp_is_topic_edit() ) {
-			$topic = get_post_field( 'post_content', bbp_get_topic_id() );
+		if ( $topic_id ) {
+			$topic = get_post_field( 'post_content', $topic_id );
 
 			return has_blocks( $topic );
 		}

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -149,10 +149,9 @@ class bbPress extends Handler {
 		$reply_id = 0;
 
 		if ( bbp_is_post_request() && ! empty( $_POST['action'] ) ) {
-			$action = $_POST['action'];
-			if ( 'bbp-edit-reply' === $action ) {
+			if ( 'bbp-edit-reply' === $_POST['action'] ) {
 				$reply_id = $_POST['bbp_reply_id'];
-			} elseif ( 'bbp-edit-topic' === $action ) {
+			} elseif ( 'bbp-edit-topic' === $_POST['action'] ) {
 				$topic_id = $_POST['bbp_topic_id'];
 			}
 		} elseif ( bbp_is_reply_edit() ) {


### PR DESCRIPTION
bbPress's `bbp_is_reply_edit()` and `bbp_is_topic_edit()` are not truthful during the subsequent POST request when editing replies/topics.

As a result, `enable_editor()` is not run if a user who has the editor disabled (through the blocks_everywhere_bbpress_editor filter) but was editing a post with blocks (so the filter value was ignored).

