### PR TITLE
Fix inline code style affecting code block

### DIFF
--- a/src/styles/theme-compat.scss
+++ b/src/styles/theme-compat.scss
@@ -182,7 +182,7 @@
 		background-color: white;
 	}
 
-	.editor-styles-wrapper code {
+	.editor-styles-wrapper p code {
 		background-color: #f0f0f0 !important;
 		padding-left: 5px !important;
 		padding-right: 5px !important;


### PR DESCRIPTION
It adds a bit of extra padding to the code block when it isn’t needed