### PR TITLE
Apply square bracket fix in general

### DIFF
--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -284,23 +284,24 @@ class bbPress extends Handler {
 	}
 
 	/**
-	 * Runs before bbPress and converts all the encoded block markup &lt;!-- wp:something --&gt; into a special [[!-- wp:somthing --]]. This
-	 * takes it out of action from the rest of bbPress, and will be restored later.
+	 * Runs before bbPress and converts all &lt; and &gt; into a special square bracket format [[lt; and gt;]]. This
+	 * takes it out of action from further encoding/decoding with the rest of bbPress. It will be restored later.
 	 *
 	 * @param string $content Content.
 	 * @return string
 	 */
 	public function allow_comments_in_bbp_encode_bad_pre( $content ) {
 		// Convert encoded markup into a square bracket version - this is if someone is typing markup as content, not as markup
-		$content = preg_replace( $this->get_markup_regex( '&lt;', '(?:&gt;|>)' ), '[[!--$1--]]', $content );
+		$content = str_replace( '&lt;', '[[lt;', $content );
+		$content = str_replace( '&gt;', 'gt;]]', $content );
 
 		return $content;
 	}
 
 	/**
 	 * Runs after bbPress. At this point bbPress has encoded all the block markup so we need to unencoded it. We also need to convert
-	 * the [!-- wp:markup --] back into encoded markup. If anyone does happen to use [[!-- wp:markup --]] in their content then it will also
-	 * be replaced with a (safe) encoded <!-- wp:markup --> version
+	 * the square bracket format back into encoded markup. If anyone does happen to use this in their content it will get replaced with
+	 * encoded &lt;/&gt; (harmless if annoying)
 	 *
 	 * @param string $content Content
 	 * @return string
@@ -315,7 +316,8 @@ class bbPress extends Handler {
 		}
 
 		// Convert the [[]] format back to encoded
-		$content = preg_replace( $this->get_markup_regex( '\[\[', '\]\]' ), '&lt;!--$1--&gt;', $content );
+		$content = str_replace( '[[lt;', '&lt;', $content );
+		$content = str_replace( 'gt;]]', '&gt;', $content );
 
 		return $content;
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,8 @@ function bbp_kses_allowed_tags() {
 		'div' => true,
 		'blockquote' => true,
 		'p' => true,
+		'pre' => true,
+		'code' => true,
 	];
 }
 

--- a/tests/test-bbpress-content.php
+++ b/tests/test-bbpress-content.php
@@ -70,8 +70,15 @@ class bbPress_Content_Test extends TestCase {
 	}
 
 	public function testSquareBrackets() {
-		$content = '<!-- wp:paragraph --><p>[[!-- wp:paragraph --]]</p><!-- /wp:paragraph -->';
+		$content = '<!-- wp:paragraph --><p>[[lt;!-- wp:paragraph --gt;]]</p><!-- /wp:paragraph -->';
 		$expected = '<!-- wp:paragraph --><p>&lt;!-- wp:paragraph --&gt;</p><!-- /wp:paragraph -->';
+
+		$this->assertEquals( $expected, $this->process_content( $content ) );
+	}
+
+	public function testCodeInCode() {
+		$content = '<!-- wp:code --><pre class="wp-block-code"><code>$link = \' &lt;a href="\' . $url . \'" alt="\' . $alt . \'" title="\' . $title . \'">\' . $linktext . \'&lt;/a> \';</code></pre><!-- /wp:code -->';
+		$expected = '<!-- wp:code --><pre class="wp-block-code"><code>$link = \' &lt;a href="\' . $url . \'" alt="\' . $alt . \'" title="\' . $title . \'"&gt;\' . $linktext . \'&lt;/a&gt; \';</code></pre><!-- /wp:code -->';
 
 		$this->assertEquals( $expected, $this->process_content( $content ) );
 	}


### PR DESCRIPTION
#99 added support for handling block markup inside content. This was too specific and needs to be made more general so we can handle any encoded HTML start/end tags inside content.

For example: `<code>&lt;code&gt;</code>`

It works in a similar way to #99 in that the encoded HTML (specifically the `<` and `>`) are replaced by another format. bbPress then does its stuff, and the encoded HTML is then replaced back afterwards.

The underlying problem is that `bbp_encode_bad` automatically encodes all HTML, including block markup. This means we end up with content that has encoded block markup and encoded user input, and we can't tell the difference.

This PR is more of a patch to fix the immediate problem (there is a unit test too).

In the longer term `bbp_encode_bad` needs to be changed so that:
- It doesn't automatically encode all HTML
- It runs whatever block processing PHP code that WordPress runs so that the content is block valid
- It performs KSES on the unencoded content