### PR TITLE
Remove extra padding from error notices

### DIFF
--- a/src/support-content-block/view.scss
+++ b/src/support-content-block/view.scss
@@ -8,6 +8,9 @@
 	&:not(:last-child) {
 		margin-bottom: 28px;
 	}
+	.components-notice.is-error.is-dismissible {
+		padding-right: 0;
+	}
 }
 
 .be-support-content {


### PR DESCRIPTION
fixes 136-gh-Automattic/lighthouse-forums

This pull request removes some extra padding so that the error notice goes from:

<img width="661" alt="image" src="https://user-images.githubusercontent.com/112691742/210226009-75b3e674-8bc0-40bd-b281-13a7018798c1.png">


To:

<img width="700" alt="image" src="https://user-images.githubusercontent.com/112691742/210226055-d65a0c9a-8d03-4292-9c6e-ee3ce6be4535.png">

Testing instructions:

* Build the plugin with `yarn release`
* Sync it to your sandbox
* Create a new content embed block, and paste an invalid url such as `https://wordress.com/forums/topic/request-a-quote-on-menu/`
* Ensure the error looks as shown in the screenshot above.
