### PR TITLE
Support blocks that have multiple scripts registered.

### DIFF
--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -297,27 +297,19 @@ class Editor {
 
 		foreach ( $block_registry->get_all_registered() as $block_type ) {
 			if ( ! empty( $block_type->style ) ) {
-				$style_handles[] = $block_type->style;
+				$style_handles = array_merge( $style_handles, (array) $block_type->style );
 			}
 
 			if ( ! empty( $block_type->editor_style ) ) {
-				$style_handles[] = $block_type->editor_style;
+				$style_handles = array_merge( $style_handles, (array) $block_type->editor_style );
 			}
 
 			if ( ! empty( $block_type->script ) ) {
-				$script_handles[] = $block_type->script;
+				$script_handles = array_merge( $script_handles, (array) $block_type->script );
 			}
 		}
 
 		$style_handles = apply_filters( 'blocks_everywhere_editor_styles', $style_handles );
-
-		// Make sure there are only strings in this array
-		$style_handles = array_filter(
-			$style_handles,
-			function( $handle ) {
-				return is_string( $handle );
-			}
-		);
 		$style_handles = array_unique( $style_handles );
 		$done          = wp_styles()->done;
 

--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -307,6 +307,10 @@ class Editor {
 			if ( ! empty( $block_type->script ) ) {
 				$script_handles = array_merge( $script_handles, (array) $block_type->script );
 			}
+
+			if ( ! empty( $block_type->view_script ) ) {
+				$script_handles = array_merge( $script_handles, (array) $block_type->view_script );
+			}
 		}
 
 		$style_handles = apply_filters( 'blocks_everywhere_editor_styles', $style_handles );


### PR DESCRIPTION
If a block is defined via block.json with multiple scripts/styles, the styles are skipped and the scripts will cause a fatal error (at least under PHP8):

```
PHP Fatal error:  Uncaught TypeError: explode(): Argument #2 ($string) must be of type string, array given in wp-includes/class-wp-dependencies.php:187
Stack trace:
#0 wp-includes/class-wp-dependencies.php(187): explode('?', Array)
#1 wp-includes/class-wp-scripts.php(650): WP_Dependencies->all_deps(Array, false, false)
#2 wp-includes/class-wp-dependencies.php(127): WP_Scripts->all_deps(Array)
#3 wp-content/plugins/blocks-everywhere/classes/class-editor.php(341): WP_Dependencies->do_items(Array)
#4 wp-includes/class-wp-hook.php(308): Automattic\Blocks_Everywhere\Editor->wp_add_iframed_editor_assets_html('')
```

This PR properly supports these by treating them as potentially arrays, which is what Gutenberg does.