### PR TITLE
Better offset for editor toolbar on wp.org

### DIFF
--- a/src/styles/theme-compat.scss
+++ b/src/styles/theme-compat.scss
@@ -264,11 +264,15 @@ body:not(.gutenberg-support-upload) {
 	overflow: scroll;
 }
 
-.wporg-support.gutenberg-support .block-editor-block-contextual-toolbar.is-fixed {
-	top: 40px;
+.gutenberg-support .blocks-everywhere .components-popover.block-editor-block-list__block-side-inserter-popover {
+	z-index: 30;
 }
 
-@media (min-width: 890px) {
+.wporg-support.gutenberg-support .block-editor-block-contextual-toolbar.is-fixed {
+	top: 92px;
+}
+
+@media (min-height: 800px) and (min-width: 890px) {
 	.wporg-support.gutenberg-support .block-editor-block-contextual-toolbar.is-fixed {
 		top: 122px;
 	}


### PR DESCRIPTION
The wp.org header shrinks when the height is < 800px and so the offset needs adjusting.