### PR TITLE
Handle support pages links with anchors in the URL

### DIFF
--- a/src/support-content-block/block.ts
+++ b/src/support-content-block/block.ts
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 
-export const SUPPORT_PAGE_PATTERN = /^https?:\/\/wordpress\.com\/((?<lang>[a-z]{2})\/)?support\/(?<slug>\S+)$/i;
+export const SUPPORT_PAGE_PATTERN = /^https?:\/\/wordpress\.com\/((?<lang>[a-z]{2})\/)?support\/(?<slug>[^# ]+)/i
 /*
 Forum Pattern cases
 


### PR DESCRIPTION
Fixes 293-gh-Automattic/lighthouse-forums

This PR updates the `SUPPORT_PAGE_PATTERN` regular expression to not consider anything after `#` as part of the slug used for retrieving pages metadata from the API.
