### PR TITLE
Load view assets even when no admin editor is loaded

### DIFF
--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -61,6 +61,9 @@ class Blocks_Everywhere {
 
 		// Admin editors
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+
+		// View assets
+		add_action( 'wp_enqueue_scripts', [ $this, 'view_enqueue_scripts' ] );
 	}
 
 	/**
@@ -116,6 +119,17 @@ class Blocks_Everywhere {
 
 				break;
 			}
+		}
+	}
+
+	/**
+	 * Load view assets
+	 *
+	 * @return void
+	 */
+	public function view_enqueue_scripts () {
+		foreach ( $this->handlers as $handler ) {
+			$handler->load_view_assets();
 		}
 	}
 }

--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -27,6 +27,13 @@ abstract class Handler {
 	private $doing_hook = null;
 
 	/**
+ 	* Constructor
+ 	*/
+	function __construct() {
+		$this->editor = new \Automattic\Blocks_Everywhere\Editor();
+	}
+
+	/**
 	 * Direct copy of core `do_blocks`, but for comments.
 	 *
 	 * This also has the benefit that we don't run `wpautop` on block transformed comments, potentially breaking them.
@@ -230,48 +237,7 @@ abstract class Handler {
 	 * @return void
 	 */
 	public function load_editor( $textarea, $container = null ) {
-		$this->editor = new \Automattic\Blocks_Everywhere\Editor();
-
-		// Settings for the editor
-		$default_settings = [
-			'editor' => $this->editor->get_editor_settings(),
-			'iso' => [
-				'blocks' => [
-					'allowBlocks' => $this->get_allowed_blocks(),
-				],
-				'moreMenu' => false,
-				'sidebar' => [
-					'inserter' => false,
-					'inspector' => false,
-				],
-				'toolbar' => [
-					'navigation' => true,
-				],
-				'defaultPreferences' => [
-					'fixedToolbar' => true,
-				],
-				'allowEmbeds' => [
-					'youtube',
-					'vimeo',
-					'wordpress',
-					'wordpress-tv',
-					'videopress',
-					'crowdsignal',
-					'imgur',
-				],
-			],
-			'saveTextarea' => $textarea,
-			'container' => $container,
-			'editorType' => $this->get_editor_type(),
-			'allowUrlEmbed' => false,
-			'pastePlainText' => false,
-			'replaceParagraphCode' => false,
-			'patchEmoji' => false,
-			'pluginsUrl' => plugins_url( '', __DIR__ ),
-			'version' => \Automattic\Blocks_Everywhere\Blocks_Everywhere::VERSION,
-		];
-
-		$settings = apply_filters( 'blocks_everywhere_editor_settings', $default_settings );
+		$settings = $this->settings();
 
 		$this->editor->load( $settings );
 		$this->settings = $settings;
@@ -288,16 +254,11 @@ abstract class Handler {
 
 		if ( in_array( 'blocks-everywhere/support-content', $settings['iso']['blocks']['allowBlocks'], true ) ) {
 			$this->enqueue_assets(
-				'support-content-view',
-				'support-content-view.min.asset.php',
-				'support-content-view.min.js',
-				'support-content-view.min.css'
-			);
-			$this->enqueue_assets(
 				'support-content-editor',
 				'support-content-editor.min.asset.php',
 				'support-content-editor.min.js',
-				'support-content-editor.min.css'
+				'support-content-editor.min.css',
+				$settings
 			);
 		}
 
@@ -323,6 +284,66 @@ abstract class Handler {
 		wp_enqueue_style( $name );
 
 		return $version;
+	}
+
+	public function load_view_assets() {
+		$settings = $this->settings();
+
+		if ( in_array( 'blocks-everywhere/support-content', $settings['iso']['blocks']['allowBlocks'], true ) ) {
+			$this->enqueue_assets(
+				'support-content-view',
+				'support-content-view.min.asset.php',
+				'support-content-view.min.js',
+				'support-content-view.min.css',
+				$settings
+			);
+		}
+	}
+
+	/**
+	 * Get configuration settings
+	 * @return mixed Array of settings
+	 */
+	private function settings() {
+				// Settings for the editor
+				$default_settings = [
+					'editor' => $this->editor->get_editor_settings(),
+					'iso' => [
+						'blocks' => [
+							'allowBlocks' => $this->get_allowed_blocks(),
+						],
+						'moreMenu' => false,
+						'sidebar' => [
+							'inserter' => false,
+							'inspector' => false,
+						],
+						'toolbar' => [
+							'navigation' => true,
+						],
+						'defaultPreferences' => [
+							'fixedToolbar' => true,
+						],
+						'allowEmbeds' => [
+							'youtube',
+							'vimeo',
+							'wordpress',
+							'wordpress-tv',
+							'videopress',
+							'crowdsignal',
+							'imgur',
+						],
+					],
+					'saveTextarea' => $textarea,
+					'container' => $container,
+					'editorType' => $this->get_editor_type(),
+					'allowUrlEmbed' => false,
+					'pastePlainText' => false,
+					'replaceParagraphCode' => false,
+					'pluginsUrl' => plugins_url( '', __DIR__ ),
+					'version' => \Automattic\Blocks_Everywhere\Blocks_Everywhere::VERSION,
+				];
+
+				return apply_filters( 'blocks_everywhere_editor_settings', $default_settings );
 	}
 
 	/**

--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -8,6 +8,8 @@ class bbPress extends Handler {
 	 * Constructor
 	 */
 	public function __construct() {
+		parent::__construct();
+
 		// Load the editor when the page has been setup, allowing us to decide based on the content
 		add_action( 'bbp_template_redirect', [ $this, 'bbp_template_redirect' ], 8 );
 

--- a/classes/handlers/class-buddypress.php
+++ b/classes/handlers/class-buddypress.php
@@ -7,6 +7,8 @@ class BuddyPress extends Handler {
 	 * Constructor
 	 */
 	public function __construct() {
+		parent::__construct();
+
 		add_action( 'bp_after_activity_post_form', [ $this, 'load_editor_buddypress' ] );
 
 		// Ensure blocks are processed when displaying

--- a/classes/handlers/class-comments.php
+++ b/classes/handlers/class-comments.php
@@ -7,6 +7,8 @@ class Comments extends Handler {
 	 * Constructor
 	 */
 	public function __construct() {
+		parent::__construct();
+
 		add_action( 'comment_form_after', [ $this, 'add_to_comments' ] );
 		add_filter( 'comment_form_defaults', [ $this, 'comment_form_defaults' ] );
 		add_filter( 'pre_comment_content', [ $this, 'remove_blocks' ] );


### PR DESCRIPTION
fixes 297-gh-Automattic/lighthouse-forums

This PR reorganises the way the "view" assets are loaded so that they also load when no admin editor is necessary. These assets are still necessary so that the block's view are rendered properly.


## Testing instructions

Apply these changes and ensure the linked issue is resolved.