### PR TITLE
Fix Content Embed popover not closing on blur

### DIFF
--- a/src/support-content-block/confirm-content.tsx
+++ b/src/support-content-block/confirm-content.tsx
@@ -11,7 +11,7 @@ export const ConfirmContent = ( { url, confirm, cancel } ) => {
 			</a>
 
 			<span className="be-support-content-confirm-anchor">
-				<Popover variant="unstyled" offset={ 16 } placement="right-start">
+				<Popover onFocusOutside={ cancel } variant="unstyled" offset={ 16 } placement="right-start">
 					<div className="be-support-content-confirm-content">
 						<Elevation value={ 3 } />
 						<NavigableMenu role="menu">

--- a/src/support-content-block/edit.tsx
+++ b/src/support-content-block/edit.tsx
@@ -3,7 +3,7 @@ import { BlockControls, useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps, createBlock } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup, withNotices } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import { renderToString, useState } from '@wordpress/element';
+import { renderToString, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { edit } from '@wordpress/icons';
 import React from 'react';
@@ -31,6 +31,11 @@ export const Edit = compose( withNotices )( ( props: EditProps ) => {
 	const [ isConfirmed, setIsConfirmed ] = useState( props.attributes.isConfirmed );
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ url, setUrl ] = useState( attributes.url );
+	const [ isReady, setIsReady ] = useState( false );
+
+	useEffect( () => {
+		setIsReady( true );
+	}, [] );
 
 	const onEditModeToggle = () => {
 		setIsEditing( ! isEditing );
@@ -67,20 +72,22 @@ export const Edit = compose( withNotices )( ( props: EditProps ) => {
 	if ( ! isConfirmed ) {
 		return (
 			<div { ...blockProps }>
-				<ConfirmContent
-					url={ url }
-					confirm={ async () => {
-						setIsConfirmed( true );
-						await fetchBlockAttributes();
-					} }
-					cancel={ () => {
-						const link = <a href={ url }>{ url }</a>;
-						const newBlock = createBlock( 'core/paragraph', {
-							content: renderToString( link ),
-						} );
-						replaceBlock( blockProps[ 'data-block' ], newBlock );
-					} }
-				/>
+				{ isReady && (
+					<ConfirmContent
+						url={ url }
+						confirm={ async () => {
+							setIsConfirmed( true );
+							await fetchBlockAttributes();
+						} }
+						cancel={ () => {
+							const link = <a href={ url }>{ url }</a>;
+							const newBlock = createBlock( 'core/paragraph', {
+								content: renderToString( link ),
+							} );
+							replaceBlock( blockProps[ 'data-block' ], newBlock );
+						} }
+					/>
+				) }
 			</div>
 		);
 	}


### PR DESCRIPTION
fixes 327-gh-Automattic/lighthouse-forums

This Pull Request fixes the focusing behaviour when pasting a link matching the Content Embed transform.

Before this change, upon pasting in the editor a link such as `https://wordpress.com/support/templates/edit-the-single-template/` the popover to convert it to an embed (or dismiss) would stay open indefinitely. This caused under the hood the embed block to stay in the editor but without the proper metadata from the API, as it was not confirmed.

Now, when the popover blurs, the embed block conversion will be "cancelled" and thus the link will stay as a normal link.

This also improves the usage of this feature with the keyboard, which previously was a bit clunky as it required several tabs to get to the right place.


### Testing instructions

1. In the editor, paste a link such as `https://wordpress.com/support/templates/edit-the-single-template/` and try to convert/dismiss the link just with the keyboard
2. Repeat the previous step, now with the mouse/trackpad
3. Pre-fill a title, some other body text, paste the link and submit the topic. It should render as a normal link as you didn't click the convert to block action menu.
4.  Ensure the linked issue is resolved

