### PR TITLE
Fix block inspector tab

### DIFF
--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Blocks Everywhere
 Description: Because somewhere is just not enough. Add Gutenberg to WordPress comments, bbPress forums, and BuddyPress streams. Also enables Gutenberg for comment & bbPress moderation.
-Version: 1.17.0
+Version: 1.17.1
 Author: Automattic
 Text Domain: 'blocks-everywhere'
 */
@@ -18,7 +18,7 @@ require_once __DIR__ . '/classes/handlers/class-buddypress.php';
 require_once __DIR__ . '/classes/handlers/class-comments.php';
 
 class Blocks_Everywhere {
-	const VERSION = '1.17.0';
+	const VERSION = '1.17.1';
 
 	/**
 	 * Instance variable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blocks-everywhere",
-	"version": "1.17.0",
+	"version": "1.17.1",
 	"description": "Gutenberg in WordPress comments, admin pages, bbPress, and BuddyPress.",
 	"main": "src/index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: johnny5, automattic
 Tags: gutenberg, comments, bbpress, buddypress
 Requires at least: 6.1
 Tested up to: 6.1
-Stable tag: 1.17.0
+Stable tag: 1.17.1
 Requires PHP: 5.6
 License: GPLv3
 
@@ -147,6 +147,9 @@ The plugin is simple to install:
 2. Gutenberg when editing a comment
 
 == Changelog ==
+
+= 1.17.1 =
+* Revert fix for block inspector tabs in 1.15.0. Gutenberg has changed again.
 
 = 1.17.0 =
 * Updates to content support block

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -55,12 +55,6 @@
 			margin-left: 0;
 		}
 	}
-
-	.edit-post-sidebar__panel-tabs {
-		button {
-			padding: 0;
-		}
-	}
 }
 
 /* Fix some Gutenberg issues when media upload is disabled */


### PR DESCRIPTION
A fix for Gutenberg 15.1.0 now seems to be removing the padding in the block inspector:

![image](https://user-images.githubusercontent.com/1277682/224949135-39b30d28-20c9-4d20-b5aa-62eba6a12e5f.png)
