### PR TITLE
Add kses additions filter for comments.

### DIFF
--- a/classes/handlers/class-comments.php
+++ b/classes/handlers/class-comments.php
@@ -28,7 +28,7 @@ class Comments extends Handler {
 	 * Filter on `wp_kses_allowed_html` -- accepting two arguments so we can only run it on the right contexts.
 	 */
 	public function filter_kses_allowed_html( $tags, $context ) {
-		if ( 'pre_comment_context' === $context ) {
+		if ( 'pre_comment_content' === $context ) {
 			// Handler::get_kses_for_allowed_blocks() doesn't accept a `$context` arg so we need to run this here.
 			$tags = $this->get_kses_for_allowed_blocks( $tags );
 		}

--- a/classes/handlers/class-comments.php
+++ b/classes/handlers/class-comments.php
@@ -19,6 +19,21 @@ class Comments extends Handler {
 			},
 			8
 		);
+
+		// Add needed tags/attributes to kses allowlist
+		add_filter( 'wp_kses_allowed_html', [ $this, 'filter_kses_allowed_html' ], 10, 2 );
+	}
+
+	/**
+	 * Filter on `wp_kses_allowed_html` -- accepting two arguments so we can only run it on the right contexts.
+	 */
+	public function filter_kses_allowed_html( $tags, $context ) {
+		if ( 'pre_comment_context' === $context ) {
+			// Handler::get_kses_for_allowed_blocks() doesn't accept a `$context` arg so we need to run this here.
+			$tags = $this->get_kses_for_allowed_blocks( $tags );
+		}
+
+		return $tags;
 	}
 
 	public function can_show_admin_editor( $hook ) {


### PR DESCRIPTION
This needs some testing, but by my reading and testing of similar functionality in an ancillary project this should do it.

Without this, logged out comments were getting even `p` tags stripped in my testing -- I think because non-block comment storage may have relied on wpautop to add it back in subsequently.