### PR TITLE
Replace WP_Theme_JSON_Resolver::theme_has_support with wp_theme_has_theme_json()

### DIFF
--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -209,7 +209,7 @@ class Editor {
 			'styles'                               => get_block_editor_theme_styles(),
 			'richEditingEnabled'                   => user_can_richedit(),
 			'postLock'                             => false,
-			'supportsLayout'                       => \WP_Theme_JSON_Resolver::theme_has_support(),
+			'supportsLayout'                       => wp_theme_has_theme_json(),
 			'__experimentalBlockPatterns'          => [],
 			'__experimentalBlockPatternCategories' => [],
 			'supportsTemplateMode'                 => current_theme_supports( 'block-templates' ),


### PR DESCRIPTION
Replaced WP_Theme_JSON_Resolver::theme_has_support with wp_theme_has_theme_json() to suppress the 6.2 Deprecation Warning.

`Deprecated: Function WP_Theme_JSON_Resolver::theme_has_support is deprecated since version 6.2.0! Use wp_theme_has_theme_json() instead. in /var/www/wp-includes/functions.php on line 5413`