### PR TITLE
Gutenberg for Term Description

### DIFF
--- a/blocks-everywhere.php
+++ b/blocks-everywhere.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/classes/class-editor.php';
 require_once __DIR__ . '/classes/handlers/class-bbpress.php';
 require_once __DIR__ . '/classes/handlers/class-buddypress.php';
 require_once __DIR__ . '/classes/handlers/class-comments.php';
+require_once __DIR__ . '/classes/handlers/class-terms.php';
 
 class Blocks_Everywhere {
 	const VERSION = '1.18.0';
@@ -72,6 +73,7 @@ class Blocks_Everywhere {
 		$default_comments = defined( 'BLOCKS_EVERYWHERE_COMMENTS' ) ? BLOCKS_EVERYWHERE_COMMENTS : false;
 		$default_bbpress = defined( 'BLOCKS_EVERYWHERE_BBPRESS' ) ? BLOCKS_EVERYWHERE_BBPRESS : false;
 		$default_buddypress = defined( 'BLOCKS_EVERYWHERE_BUDDYPRESS' ) ? BLOCKS_EVERYWHERE_BUDDYPRESS : false;
+		$default_terms = defined( 'BLOCKS_EVERYWHERE_TERMS' ) ? BLOCKS_EVERYWHERE_TERMS : false;
 
 		if ( apply_filters( 'blocks_everywhere_comments', $default_comments ) ) {
 			$this->handlers['Comments'] = new Handler\Comments();
@@ -84,12 +86,16 @@ class Blocks_Everywhere {
 		if ( apply_filters( 'blocks_everywhere_buddypress', $default_buddypress ) ) {
 			$this->handlers['BuddyPress'] = new Handler\BuddyPress();
 		}
+
+		if ( apply_filters( 'blocks_everywhere_terms', $default_terms ) ) {
+			$this->handlers['Terms'] = new Handler\Terms();
+		}
 	}
 
 	/**
 	 * Get the instantiated handler class for the specified type, or null if it isn't configured or known.
 	 *
-	 * @param 'Comments'|'bbPress'|'BuddyPress' $which The handler type.
+	 * @param 'Comments'|'bbPress'|'BuddyPress'|'Terms' $which The handler type.
 	 * @return Handler\Handler|null object or null it not configured.
 	 */
 	public function get_handler( $which ) {

--- a/classes/handlers/class-terms.php
+++ b/classes/handlers/class-terms.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Automattic\Blocks_Everywhere\Handler;
+
+class Terms extends Handler {
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		/* Only users with the "publish_posts" capability can use this feature */
+		if ( current_user_can( 'publish_posts' ) ) {
+
+			/* Remove the filters which disallow HTML in term descriptions */
+			remove_filter( 'pre_term_description', 'wp_filter_kses' );
+			remove_filter( 'term_description', 'wp_kses_data' );
+
+			/* Add filters to disallow unsafe HTML tags */
+			if ( ! current_user_can( 'unfiltered_html' ) ) {
+				add_filter( 'pre_term_description', 'wp_kses_post' );
+				add_filter( 'term_description', 'wp_kses_post' );
+			}
+		}
+
+		add_filter( 'pre_term_description', [ $this, 'remove_blocks' ] );
+
+		/* Loop through the taxonomies, adding actions */
+		$taxonomies = get_taxonomies( [
+			'show_ui' => true,
+			'public' => true,
+		] );
+		foreach ( $taxonomies as $taxonomy ) {
+			add_action( $taxonomy . '_edit_form_fields', [ $this, 'add_to_terms_edit' ], 1, 2 );
+			add_action( $taxonomy . '_add_form_fields', [ $this, 'add_to_terms_add' ], 1, 1 );
+		}
+
+		// Ensure blocks are processed when displaying
+		add_filter(
+			'term_description',
+			function( $content ) {
+				return $this->do_blocks( $content, 'term_description' );
+			},
+			8
+		);
+	}
+
+	public function can_show_admin_editor( $hook ) {
+		return $hook === 'term.php';
+	}
+
+	public function get_editor_type() {
+		return 'core';
+	}
+
+	/**
+	 * Get the HTML that the editor uses on the page
+	 *
+	 * @return void
+	 */
+	public function add_to_terms_edit() {
+		$this->load_editor( '#description' );
+	}
+
+	/**
+	 * Get the HTML that the editor uses on the page
+	 *
+	 * @return void
+	 */
+	public function add_to_terms_add() {
+		$this->load_editor( '#tag-description' );
+	}
+
+	public function wp_editor_settings( $settings ) {
+		$settings['tinymce'] = true;
+		$settings['quicktags'] = true;
+		return $settings;
+	}
+}

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -21,3 +21,4 @@
 @import "./comments.scss";
 @import "./bbpress.scss";
 @import "./editor.scss";
+@import "./terms.scss";

--- a/src/styles/terms.scss
+++ b/src/styles/terms.scss
@@ -1,0 +1,6 @@
+// Terms
+.gutenberg-support-loaded {
+	textarea#description, textarea#tag-description {
+		display: none;
+	}
+}


### PR DESCRIPTION
As suggested here https://github.com/Automattic/blocks-everywhere/issues/20 I tried to add support for the term description.

It works, but it is still wip because I need your help:

1. (Done) As the term description is only in the backend, I would propose supporting all blocks, not just a limited set.
2. I think it would be helpful if Gutenberg uses the full page with. Currently, the edit form limited to `max-width: 800px`. I would propose to override it with 100%.
3. (Works now) In the past, I used https://github.com/sheabunge/visual-term-description-editor to have at least the classic editor for the term description. But if there is an old description, it breaks because it has to be converted to blocks first. This is disabled, but I don't know how to enable it again for the term description.