### PR TITLE
Extend editor props to accept __experimentalOnChange and __experiment…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ For extra security the list of available blocks is determined by the allowed tag
 Gutenberg is not bundled and instead is side-loaded from WordPress. For better compatibility you should use the plugin version of Gutenberg, which is typically several versions ahead of the one included in WordPress.
 
 The condition of the Gutenberg replacements are:
-- bbPress - good (requires bbPress 2.6+)
-- comments - alright
-- BuddyPress - needs a lot of work
+
+-   bbPress - good (requires bbPress 2.6+)
+-   comments - alright
+-   BuddyPress - needs a lot of work
 
 The plugin uses the [Isolated Block Editor](https://github.com/Automattic/isolated-block-editor/). This can also be found in:
 
-- [Plain Text Editor](https://github.com/Automattic/isolated-block-editor/src/browser/README.md) - standalone JS file that can replace any `textarea` on any page with a full Gutenberg editor
-- [Gutenberg Chrome Extension](https://github.com/Automattic/gutenberg-everywhere-chrome/) - a Chrome extension that allows Gutenberg to be used on any page
-- [Gutenberg Desktop](https://github.com/Automattic/gutenberg-desktop/) - a desktop editor that supports the loading and saving of HTML and Markdown files
-- [P2](https://wordpress.com/p2/) - WordPress as a collaborative workspace (coming soon for self-hosted)
+-   [Plain Text Editor](https://github.com/Automattic/isolated-block-editor/src/browser/README.md) - standalone JS file that can replace any `textarea` on any page with a full Gutenberg editor
+-   [Gutenberg Chrome Extension](https://github.com/Automattic/gutenberg-everywhere-chrome/) - a Chrome extension that allows Gutenberg to be used on any page
+-   [Gutenberg Desktop](https://github.com/Automattic/gutenberg-desktop/) - a desktop editor that supports the loading and saving of HTML and Markdown files
+-   [P2](https://wordpress.com/p2/) - WordPress as a collaborative workspace (coming soon for self-hosted)
 
 Blocks Everywhere can be downloaded from WordPress.org:
 
@@ -74,6 +75,10 @@ Some settings are available through the settings object, which is filterable wit
 `patchEmoji` - set to `true` to stop twemoji from affecting the editor
 `iso.allowEmbeds` - List of enabled embeds
 `iso.blocks.allowBlocks` - List of enabled blocks
+`iso.className` - String of classes to be assigned to the editor.
+`iso.__experimentalOnChange` - An optional callback that is triggered when the blocks are changed.
+`iso.__experimentalOnInput` - An optional callback that is triggered when text is input.
+`iso.__experimentalOnSelection` - An optional callback when a block is selected.
 
 ### Theme compatibility
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,10 @@ Some settings are available through the settings object, which is filterable wit
 `patchEmoji` - set to `true` to stop twemoji from affecting the editor
 `iso.allowEmbeds` - List of enabled embeds
 `iso.blocks.allowBlocks` - List of enabled blocks
+`iso.className` - String of classes to be assigned to the editor.
+`iso.__experimentalOnChange` - An optional callback that is triggered when the blocks are changed.
+`iso.__experimentalOnInput` - An optional callback that is triggered when text is input.
+`iso.__experimentalOnSelection` - An optional callback when a block is selected.
 
 == Theme compatibility ==
 

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -64,6 +64,12 @@ function createEditorContainer( container, textarea, settings ) {
 			onSaveContent={ ( content ) => saveBlocks( textarea, content ) }
 			onLoad={ ( parser ) => ( textarea && textarea.nodeName === 'TEXTAREA' ? parser( textarea.value ) : [] ) }
 			onError={ () => document.location.reload() }
+			__experimentalOnInput={ () =>
+				typeof settings?.iso?.__experimentalOnInput === 'function' && settings?.iso.__experimentalOnInput()
+			}
+			__experimentalOnChange={ () =>
+				typeof settings?.iso?.__experimentalOnChange === 'function' && settings?.iso.__experimentalOnChange()
+			}
 		>
 			<EditorLoaded onLoaded={ () => setLoaded( container ) } />
 

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -64,12 +64,10 @@ function createEditorContainer( container, textarea, settings ) {
 			onSaveContent={ ( content ) => saveBlocks( textarea, content ) }
 			onLoad={ ( parser ) => ( textarea && textarea.nodeName === 'TEXTAREA' ? parser( textarea.value ) : [] ) }
 			onError={ () => document.location.reload() }
-			__experimentalOnInput={ () =>
-				typeof settings?.iso?.__experimentalOnInput === 'function' && settings?.iso.__experimentalOnInput()
-			}
-			__experimentalOnChange={ () =>
-				typeof settings?.iso?.__experimentalOnChange === 'function' && settings?.iso.__experimentalOnChange()
-			}
+			__experimentalOnInput={ ( newBlocks ) => settings?.iso.__experimentalOnInput?.( newBlocks ) }
+			__experimentalOnChange={ ( newBlocks ) => settings?.iso.__experimentalOnChange?.( newBlocks ) }
+			__experimentalOnSelection={ ( selection ) => settings?.iso.__experimentalOnSelection?.( selection ) }
+			className={ settings?.iso?.className }
 		>
 			<EditorLoaded onLoaded={ () => setLoaded( container ) } />
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -7,8 +7,10 @@ declare interface Blocks {
 declare interface Iso {
 	allowEmbeds: string[];
 	blocks: Blocks;
-	__experimentalOnInput?: () => void;
-	__experimentalOnChange?: () => void;
+	__experimentalOnInput?: ( block: any ) => any;
+	__experimentalOnChange?: ( block: any ) => any;
+	__experimentalOnSelection?: ( selection: any ) => any;
+	className?: string;
 }
 
 declare var wpBlocksEverywhere: {

--- a/types.d.ts
+++ b/types.d.ts
@@ -7,6 +7,8 @@ declare interface Blocks {
 declare interface Iso {
 	allowEmbeds: string[];
 	blocks: Blocks;
+	__experimentalOnInput?: () => void;
+	__experimentalOnChange?: () => void;
 }
 
 declare var wpBlocksEverywhere: {


### PR DESCRIPTION
## Summary

There are a few helpful callbacks that are currently available in the isolate-block-editor that are no included in blocks-everywhere. These would be very helpful to have access to.

The PR adds the callbacks to `wpBlocksEverywhere` setting and leaves them as optional to avoid any conflicts if there is noting set. The three most helpful callbacks I thought would be `onChange`, `onInput`, `onSelection`.

This also updates the README with the new props.

## Testing

1. Setup the testing environment of your choice.
2. Go to a page where blocks-everywhere is loaded.
3. Everything should be working with no regressions.
4. Use the dev console to set callback functions like this:

```
wpBlocksEverywhere.iso.__experimentalOnSelection = ( selection ) => console.log( 'Selection', selection );
wpBlocksEverywhere.iso.__experimentalOnInput = ( selection ) => console.log( 'Input', selection );
wpBlocksEverywhere.iso.__experimentalOnChange = ( selection ) => console.log( 'Change', selection );
```

5. Now go back and use the editor to see the outputs in the console.