### PR TITLE
Reset the position of the toolbar for compat with Gutenberg 15.7+

### DIFF
--- a/src/styles/theme-compat.scss
+++ b/src/styles/theme-compat.scss
@@ -283,11 +283,10 @@ body:not(.gutenberg-support-upload) {
 }
 
 .wporg-support.gutenberg-support .block-editor-block-contextual-toolbar.is-fixed {
-	top: 92px;
-}
+	position: static;
+	margin-left: 0;
 
-@media (min-height: 800px) and (min-width: 890px) {
-	.wporg-support.gutenberg-support .block-editor-block-contextual-toolbar.is-fixed {
-		top: 122px;
+	&:not(:empty) {
+		border-bottom: 1px solid #e0e0e0;
 	}
 }


### PR DESCRIPTION
See https://github.com/Automattic/blocks-everywhere/issues/176

This switches the toolbar to be static-positioned on wp.org, so that it shows up above the post editor rather than floating outside it. It does remove the "fixed" aspect, if you write a long topic, the toolbar scrolls off screen.

This is really just a workaround for wordpress.org, so that we can unpin the version of Gutenberg — it doesn't do anything to fix the issue anywhere else the editor is used. This could be ported as a quick fix for other editors, or (more likely) it needs a better solution. So feel free to take or leave this PR 🙂 

| Before | After |
|---|---|
| <img width="771" alt="Screenshot 2023-06-15 at 2 00 45 PM" src="https://github.com/Automattic/blocks-everywhere/assets/541093/779c8b22-43d8-4205-a299-32f9ea4d50e8"> | <img width="631" alt="Screenshot 2023-06-15 at 1 55 26 PM" src="https://github.com/Automattic/blocks-everywhere/assets/541093/8f2836c3-05b1-4c48-adbf-674db42fd707"> |

