### PR TITLE
Dynamic Loading: tweaks to allow for dynamic loading of scripts

### DIFF
--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -92,16 +92,18 @@ class Editor {
 		// Restrict tinymce buttons
 		add_filter( 'tiny_mce_before_init', [ $this, 'tiny_mce_before_init' ] );
 
+		// Keep Jetpack out of things
+		add_filter(
+			'jetpack_blocks_variation',
+			function() {
+				return 'no-post-editor';
+			}
+		);
+		
+		// Only call the editor assets if we are not dynamically loading.
 		if ( ! defined( '__EXPERIMENTAL_DYNAMIC_LOAD' ) ) {
-			// Keep Jetpack out of things
-			add_filter(
-				'jetpack_blocks_variation',
-				function() {
-					return 'no-post-editor';
-				}
-			);
-
 			wp_tinymce_inline_scripts();
+
 			wp_enqueue_editor();
 
 			do_action( 'enqueue_block_editor_assets' );

--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -92,30 +92,32 @@ class Editor {
 		// Restrict tinymce buttons
 		add_filter( 'tiny_mce_before_init', [ $this, 'tiny_mce_before_init' ] );
 
-		// Gutenberg scripts
-		wp_enqueue_script( 'wp-block-library' );
-		wp_enqueue_script( 'wp-format-library' );
-		wp_enqueue_script( 'wp-editor' );
-		wp_enqueue_script( 'wp-plugins' );
+		if ( ! defined( '__EXPERIMENTAL_DYNAMIC_LOAD' ) ) {
+			// Gutenberg scripts
+			wp_enqueue_script( 'wp-block-library' );
+			wp_enqueue_script( 'wp-format-library' );
+			wp_enqueue_script( 'wp-editor' );
+			wp_enqueue_script( 'wp-plugins' );
+
+			// Keep Jetpack out of things
+			add_filter(
+				'jetpack_blocks_variation',
+				function() {
+					return 'no-post-editor';
+				}
+			);
+
+			wp_tinymce_inline_scripts();
+			wp_enqueue_editor();
+
+			do_action( 'enqueue_block_editor_assets' );
+
+			add_action( 'wp_print_footer_scripts', array( '_WP_Editors', 'print_default_editor_scripts' ), 45 );
+		}
 
 		// Gutenberg styles
 		wp_enqueue_style( 'wp-edit-post' );
 		wp_enqueue_style( 'wp-format-library' );
-
-		// Keep Jetpack out of things
-		add_filter(
-			'jetpack_blocks_variation',
-			function() {
-				return 'no-post-editor';
-			}
-		);
-
-		wp_tinymce_inline_scripts();
-		wp_enqueue_editor();
-
-		do_action( 'enqueue_block_editor_assets' );
-
-		add_action( 'wp_print_footer_scripts', array( '_WP_Editors', 'print_default_editor_scripts' ), 45 );
 
 		$this->setup_rest_api();
 

--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -93,12 +93,6 @@ class Editor {
 		add_filter( 'tiny_mce_before_init', [ $this, 'tiny_mce_before_init' ] );
 
 		if ( ! defined( '__EXPERIMENTAL_DYNAMIC_LOAD' ) ) {
-			// Gutenberg scripts
-			wp_enqueue_script( 'wp-block-library' );
-			wp_enqueue_script( 'wp-format-library' );
-			wp_enqueue_script( 'wp-editor' );
-			wp_enqueue_script( 'wp-plugins' );
-
 			// Keep Jetpack out of things
 			add_filter(
 				'jetpack_blocks_variation',


### PR DESCRIPTION
## Summary
We are working towards allowing the editor to dynamically load all the major scripts. This PR is the first step. It does 3 things.

1. Moves the inline settings script to its own handle. This prevents errors that can arise when delaying the load of the main script.
2. It utilizes a new class that is being built to dynamically enqueue the scripts from PHP and trigger them from JS. The class is `WP_Enqueue_Dynamic_Script`. This will only be applied to the main script and only if `__EXPERIMENTAL_DYNAMIC_LOAD` is defined and true.
3. The editor scripts are no longer enqueued if the `__EXPERIMENTAL_DYNAMIC_LOAD` is defined.

## Testing
1. Setup the testing environment of your choice.
2. Go to a page where blocks-everywhere is loaded.
3. Everything should be working with no regressions.

## Context for Automatticians

pdDR7T-Q9-p2