### PR TITLE
Don't call do_blocks on non-block comments

### DIFF
--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -68,6 +68,10 @@ abstract class Handler {
 	 * @return String
 	 */
 	public function do_blocks( $content, $hook ) {
+		// Don't touch non-block comments.
+		if ( ! has_blocks( $content ) ) {
+			return $content;
+		}
 		$blocks = parse_blocks( $content );
 		$output = '';
 


### PR DESCRIPTION
Parsing plain text is wasteful, and more importantly breaks core WordPress tests when Blocks Everywhere is enabled.

Because the core tests have a comment with the body "Hello World", which is parsed into a block without a name. And this breaks this [assertion](https://core.trac.wordpress.org/browser/trunk/tests/phpunit/tests/blocks/renderCommentTemplate.php?rev=56262#L621), since the comment will contain 6 blocks (not 5) and one of them will be a nameless block with `innerHTML=Hello World`.