### PR TITLE
Styles: allow opting out of styles

### DIFF
--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -111,14 +111,16 @@ class Editor {
 			add_action( 'wp_print_footer_scripts', array( '_WP_Editors', 'print_default_editor_scripts' ), 45 );
 		}
 
-		// Gutenberg styles
-		wp_enqueue_style( 'wp-edit-post' );
-		wp_enqueue_style( 'wp-format-library' );
+		// Optionally skip loading the editor styles.
+		if ( ! defined( 'NO_EDITOR_STYLES' ) ) {
+			wp_enqueue_style( 'wp-edit-post' );
+			wp_enqueue_style( 'wp-format-library' );
+
+			set_current_screen( 'front' );
+			wp_styles()->done = array( 'wp-reset-editor-styles' );
+		}
 
 		$this->setup_rest_api();
-
-		set_current_screen( 'front' );
-		wp_styles()->done = array( 'wp-reset-editor-styles' );
 
 		$categories = wp_json_encode( get_block_categories( $post ) );
 

--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -112,7 +112,9 @@ class Editor {
 		}
 
 		// Optionally skip loading the editor styles.
-		if ( ! defined( 'NO_EDITOR_STYLES' ) ) {
+		$should_inline_styles = apply_filters( 'blocks_everywhere_should_enqueue_styles' , true );
+
+		if ( $should_inline_styles ) {
 			wp_enqueue_style( 'wp-edit-post' );
 			wp_enqueue_style( 'wp-format-library' );
 


### PR DESCRIPTION
## Summary

Since Gutenberg is being loaded on the front end there are many collisions with styling from themes. This is not limited to the editor getting styled by the theme, the use of `wp_styles()->done = array( 'wp-reset-editor-styles' );` is resetting some of the styles on the theme.

To avoid this I would like to make loading the styles optional to allow us to load the necessary core stylesheets nested within our plugins styles.

```
		@include meta.load-css('@wordpress/components/build-style/style-rtl.css');
		@include meta.load-css('@wordpress/format-library/build-style/style-rtl.css');
		@include meta.load-css('@wordpress/edit-post/build-style/style-rtl.css');
```

This is tested and working in the following https://github.com/Automattic/verbum/pull/13.
