### PR TITLE
bbPress user mentions broken: Incorrect function checked for.

### DIFF
--- a/classes/handlers/class-bbpress.php
+++ b/classes/handlers/class-bbpress.php
@@ -490,7 +490,7 @@ class bbPress extends Handler {
 	 * @return array
 	 */
 	public function get_topic_users( $topic_id = 0 ) {
-		if ( ! function_exists( 'get_topic_users' ) ) {
+		if ( ! function_exists( 'bbp_get_topic_id' ) ) {
 			return [];
 		}
 


### PR DESCRIPTION
Via https://meta.trac.wordpress.org/ticket/7320 it's been noticed that the bbPress user mentions has been broken for some time.

It turns out that https://github.com/Automattic/blocks-everywhere/commit/a49eaba461d15cfd2df9c569ff730439cc368ef0 / https://github.com/Automattic/blocks-everywhere/commit/a6bfeeb08262e798278e26cc100578e7abf37219  via #189 was added with the incorrect function check.

`get_topic_users()` doesn't exist, and isn't used in the function.

