### PR TITLE
Support Underline & Language selection

### DIFF
--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -263,6 +263,8 @@ abstract class Handler {
 		$tags['mark'] = [ 'class' => true ];
 		$tags['sub'] = [];
 		$tags['sup'] = [];
+		$tags['span'] = [ 'style' => true ];
+		$tags['bdo'] = [ 'lang' => true, 'dir' => true ];
 
 		return $tags;
 	}


### PR DESCRIPTION
As reported in https://wordpress.org/support/topic/issue-with-underline-rendering-in-forum/ & https://meta.trac.wordpress.org/ticket/7599 certain styles are not being respected properly.

This PR adds the needed tags for Underline and Language selection.

Note: For WordPress.org I'm likely to remove some of these once I figure out how :)