### PR TITLE
Allow extenders to remove additional format types.

### DIFF
--- a/classes/class-handler.php
+++ b/classes/class-handler.php
@@ -331,6 +331,10 @@ abstract class Handler {
 					'imgur',
 				],
 			],
+			'unregisterFormatType' => [
+				'core/text-color',
+				'core/image',
+			],
 			'editorType' => $this->get_editor_type(),
 			'allowUrlEmbed' => false,
 			'pastePlainText' => false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,9 +39,8 @@ domReady( () => {
 	// Modify any blocks we need to
 	addFilter( 'blocks.registerBlockType', 'blocks-everywhere/modify-blocks', customBlocks );
 
-	// Remove some formatting options
-	unregisterFormatType( 'core/text-color' );
-	unregisterFormatType( 'core/image' );
+	// Remove any formatting options we need to disable
+	wpBlocksEverywhere?.unregisterFormatType.forEach( ( formatType ) => unregisterFormatType( formatType ) );
 
 	if ( wpBlocksEverywhere.editorType === 'bbpress' && wpBlocksEverywhere.autocompleter ) {
 		addFilter(


### PR DESCRIPTION
Instead of rolling our own plugin to extend the editor, it would be useful if the list of unsupported format types was defined through the PHP Configuration of Blocks Everywhere.

For example; See https://meta.trac.wordpress.org/changeset/13561 for how this PR is being used currently.