### PR TITLE
Build theme.json object by updating the existing value.

### DIFF
--- a/classes/class-editor.php
+++ b/classes/class-editor.php
@@ -26,11 +26,11 @@ class Editor {
 	/**
 	 * Provide theme.json
 	 *
-	 * @param \WP_Theme_JSON_Data_Gutenberg $json JSON.
-	 * @return \WP_Theme_JSON_Data_Gutenberg
+	 * @param \WP_Theme_JSON_Data $theme_json JSON.
+	 * @return \WP_Theme_JSON_Data
 	 */
-	public function wp_theme_json_data_theme( $json ) {
-		$theme = new \WP_Theme_JSON_Data_Gutenberg(
+	public function wp_theme_json_data_theme( $theme_json ) {
+		$new_data = array(
 			[
 				'version' => 2,
 				'settings' => [
@@ -59,7 +59,7 @@ class Editor {
 			]
 		);
 
-		return $theme;
+		return $theme_json->update_with( $new_data );
 	}
 
 	/**


### PR DESCRIPTION
This fixes a compatibility issue with Gutenberg <18.5 and WordPress 6.6.

Returning a `WP_Theme_JSON_Data_Gutenberg` from this filter leads to "Call to undefined method WP_Theme_JSON_Data_Gutenberg::get_theme_json()" when used on the WordPress 6.6 beta. According to [this dev note](https://make.wordpress.org/core/2022/10/10/filters-for-theme-json-data/), the value should be set using `update_with( … );`, which then returns the correct class. It's also more future-friendly, as the post mentions:

> By using this mechanism as suggested, core will always make sure their data gets migrated to the latest.

I've also updated the docblock to reflect the updated classes.

See https://core.trac.wordpress.org/ticket/61112

To test

- Use Gutenberg 17.9 & WordPress 6.6 beta
- View a front-end editor
- Before this PR, it would fatal error
- With the PR, it should render correctly
